### PR TITLE
Add prompt template retrieval endpoint

### DIFF
--- a/features/prompt-registry.mdx
+++ b/features/prompt-registry.mdx
@@ -498,7 +498,7 @@ template = promptlayer.templates.get(
     }
   }
 )
-response = openai.chat.completions.create(**template["llm_kwargs"])
+response = client.chat.completions.create(**template["llm_kwargs"])
 ```
 
 ```python Python SDK
@@ -512,7 +512,7 @@ template = promptlayer.templates.get(
     }
   }
 )
-response = openai.chat.completions.create(
+response = client.chat.completions.create(
   **template["llm_kwargs"],
   model="gpt-3.5-turbo",
 )

--- a/features/prompt-registry.mdx
+++ b/features/prompt-registry.mdx
@@ -32,30 +32,20 @@ It’s simple.
 <CodeGroup>
 
 ```python Python SDK
-template_dict = promptlayer.templates.get(prompt_name="my_template")
-```
-
-```python Python SDK (Legacy)
-template_dict = promptlayer.prompts.get("my_template")
+template_dict = promptlayer.templates.get("my_template")
 ```
 
 ```js JavaScript
 const template_dict = await promptlayer.templates.get("my_template");
 ```
 
-```js JavaScript (Legacy)
-
-```js JavaScript (Legacy)
-const template_dict = await promptlayer.prompts.get({ prompt_name: "my_template" });
-```
-
 </CodeGroup>
 
 Alternatively, use the REST API endpoint `/rest/get-prompt-template` ([read more](/reference/get-prompt-template)).
 
-_Note:_ We have a new prompt template schema that is more flexible and powerful. If you are using the new schema, you can use the `promptlayer.templates.get` method to get a template. If you are using the old schema, you can use the `promptlayer.prompts.get` method to get a template. Notice how `promptlayer.prompts.get` will always return templates in legacy shape, while `promptlayer.templates.get` will always return templates in the new shape.
+*Note:* We have deprecated the legacy prompt template schema. Use `promptlayer.templates.get` to retrieve prompt templates. Notice how `promptlayer.prompts.get` will always return templates in legacy shape. 
 
-For REST API of fetching a prompt template in new schema, please refer to `/prompt-templates` ([read more](/reference/templates-get)).
+For REST API of fetching a prompt template, please refer to `/prompt-templates` ([read more](/reference/templates-get)).
 
 ### By Release Label
 
@@ -64,14 +54,21 @@ Release labels like `prod` and `staging` can be optionally applied to template v
 <CodeGroup>
 
 ```python Python SDK
-promptlayer.prompts.get("my_template", label="prod")
+promptlayer.templates.get(
+  "my_template",
+  {
+    "label": "prod"
+  }
+)
 ```
 
 ```js JavaScript
-const template_dict = await promptlayer.prompts.get({
-  prompt_name: "my_template",
-  label: "prod"
-});
+const template_dict = await promptlayer.templates.get(
+  "my_template",
+  {
+    label: "prod"
+  }
+);
 ```
 
 </CodeGroup>
@@ -83,13 +80,22 @@ You can also optionally pass `version` to get an older version of a prompt. By d
 <CodeGroup>
 
 ```python Python SDK
-template_dict = promptlayer.prompts.get("my_template", version=3)
+template_dict = promptlayer.templates.get(
+  "my_template",
+  {
+    "version": 3
+  }
+)
 ```
 
 ```js JavaScript
-const template_dict = await promptlayer.prompts.get({
-  prompt_name: "my_template", version: 3
-});
+const template_dict = await promptlayer.templates.get(
+  "my_template",
+  {
+    version: 3
+  }
+);
+
 ```
 
 </CodeGroup>
@@ -101,13 +107,13 @@ When fetching a prompt template, you can optionally retrieve metadata by using `
 <CodeGroup>
 
 ```python Python SDK
-template, metadata = promptlayer.prompts.get("my_template", include_metadata=True)
+template = promptlayer.templates.get("my_template")
+print(template["metadata"])
 ```
 
 ```js JavaScript
-const template = await promptlayer.prompts.get({
-  prompt_name: "my_template"
-});
+const template = await promptlayer.templates.get("my_template");
+console.log(template.metadata);
 ```
 
 </CodeGroup>
@@ -503,8 +509,8 @@ The following code snippet shows you how to do this:
 
 ```python Python SDK (Metadata)
 template = promptlayer.templates.get(
-  prompt_name="my_prompt_with_functions",
-  params={
+  "my_prompt_with_functions",
+  {
     "provider": "openai",
     "input_variables": {
       "location": "Boston, MA",
@@ -517,8 +523,8 @@ response = openai.chat.completions.create(**template["llm_kwargs"])
 
 ```python Python SDK
 template = promptlayer.templates.get(
-  prompt_name="my_prompt_with_functions",
-  params={
+  "my_prompt_with_functions",
+  {
     "provider": "openai",
     "input_variables": {
       "location": "Boston, MA",

--- a/features/prompt-registry.mdx
+++ b/features/prompt-registry.mdx
@@ -32,16 +32,30 @@ It’s simple.
 <CodeGroup>
 
 ```python Python SDK
+template_dict = promptlayer.templates.get(prompt_name="my_template")
+```
+
+```python Python SDK (Legacy)
 template_dict = promptlayer.prompts.get("my_template")
 ```
 
 ```js JavaScript
+const template_dict = await promptlayer.templates.get("my_template");
+```
+
+```js JavaScript (Legacy)
+
+```js JavaScript (Legacy)
 const template_dict = await promptlayer.prompts.get({ prompt_name: "my_template" });
 ```
 
 </CodeGroup>
 
 Alternatively, use the REST API endpoint `/rest/get-prompt-template` ([read more](/reference/get-prompt-template)).
+
+_Note:_ We have a new prompt template schema that is more flexible and powerful. If you are using the new schema, you can use the `promptlayer.templates.get` method to get a template. If you are using the old schema, you can use the `promptlayer.prompts.get` method to get a template. Notice how `promptlayer.prompts.get` will always return templates in legacy shape, while `promptlayer.templates.get` will always return templates in the new shape.
+
+For REST API of fetching a prompt template in new schema, please refer to `/prompt-templates` ([read more](/reference/templates-get)).
 
 ### By Release Label
 
@@ -487,7 +501,38 @@ The following code snippet shows you how to do this:
 
 <CodeGroup>
 
+```python Python SDK (Metadata)
+template = promptlayer.templates.get(
+  prompt_name="my_prompt_with_functions",
+  params={
+    "provider": "openai",
+    "input_variables": {
+      "location": "Boston, MA",
+      "unit": "fahrenheit",
+    }
+  }
+)
+response = openai.chat.completions.create(**template["llm_kwargs"])
+```
+
 ```python Python SDK
+template = promptlayer.templates.get(
+  prompt_name="my_prompt_with_functions",
+  params={
+    "provider": "openai",
+    "input_variables": {
+      "location": "Boston, MA",
+      "unit": "fahrenheit",
+    }
+  }
+)
+response = openai.chat.completions.create(
+  **template["llm_kwargs"],
+  model="gpt-3.5-turbo",
+)
+```
+
+```python Python SDK (Legacy)
 def get_message(chat_message):
     if "prompt" in chat_message:
         return {"role": chat_message.get("role"), "content":chat_message.get("prompt", {}).get("template", "")}
@@ -508,7 +553,38 @@ response = openai.ChatCompletion.create(
 )
 ```
 
+```js JavaScript (Metadata)
+const prompt = await promptlayer.templates.get(
+  "my_prompt_with_functions",
+  {
+    provider: "openai",
+    input_variables: {
+      location: "Boston, MA",
+      unit: "fahrenheit",
+    },
+  }
+)
+const response = await openai.completions.create(prompt.llm_kwargs)
+```
+
 ```js JavaScript
+const prompt = await promptlayer.templates.get(
+  "my_prompt_with_functions",
+  {
+    provider: "openai",
+    input_variables: {
+      location: "Boston, MA",
+      unit: "fahrenheit",
+    },
+  }
+);
+const response = await openai.completions.create({
+  ...prompt.llm_kwargs,
+  model: "gpt-3.5-turbo",
+});
+```
+
+```js JavaScript (Legacy)
 const get_message = (chat_message) => {
   if ("prompt" in chat_message) {
     return {

--- a/features/prompt-registry.mdx
+++ b/features/prompt-registry.mdx
@@ -43,9 +43,9 @@ const template_dict = await promptlayer.templates.get("my_template");
 
 Alternatively, use the REST API endpoint `/rest/get-prompt-template` ([read more](/reference/get-prompt-template)).
 
-*Note:* We have deprecated the legacy prompt template schema. Use `promptlayer.templates.get` to retrieve prompt templates. Notice how `promptlayer.prompts.get` will always return templates in legacy shape. 
+*Note*: Please use `promptlayer.templates.get` to access prompt templates. `The promptlayer.prompts.get` function is deprecated and returns templates in the legacy format.
 
-For REST API of fetching a prompt template, please refer to `/prompt-templates` ([read more](/reference/templates-get)).
+To fetch a prompt template using the REST API, refer to the endpoint endpoint `/prompt-templates` ([read more](/reference/templates-get)).
 
 ### By Release Label
 
@@ -54,21 +54,11 @@ Release labels like `prod` and `staging` can be optionally applied to template v
 <CodeGroup>
 
 ```python Python SDK
-promptlayer.templates.get(
-  "my_template",
-  {
-    "label": "prod"
-  }
-)
+promptlayer.templates.get("my_template", { "label": "prod" })
 ```
 
 ```js JavaScript
-const template_dict = await promptlayer.templates.get(
-  "my_template",
-  {
-    label: "prod"
-  }
-);
+const template_dict = await promptlayer.templates.get("my_template", { label: "prod" });
 ```
 
 </CodeGroup>
@@ -80,21 +70,11 @@ You can also optionally pass `version` to get an older version of a prompt. By d
 <CodeGroup>
 
 ```python Python SDK
-template_dict = promptlayer.templates.get(
-  "my_template",
-  {
-    "version": 3
-  }
-)
+template_dict = promptlayer.templates.get("my_template", { "version": 3 })
 ```
 
 ```js JavaScript
-const template_dict = await promptlayer.templates.get(
-  "my_template",
-  {
-    version: 3
-  }
-);
+const template_dict = await promptlayer.templates.get("my_template", { version: 3 });
 
 ```
 

--- a/mint.json
+++ b/mint.json
@@ -72,14 +72,14 @@
       "pages": [
         "reference/rest-api-reference",
         "reference/track-request",
+        "reference/templates-get",
         "reference/get-prompt-template",
         "reference/publish-prompt-template",
         "reference/track-score",
         "reference/track-prompt",
         "reference/track-group",
         "reference/track-metadata",
-        "reference/get-prompts",
-        "reference/templates-get"
+        "reference/get-prompts"
       ]
     }
   ],

--- a/mint.json
+++ b/mint.json
@@ -78,7 +78,8 @@
         "reference/track-prompt",
         "reference/track-group",
         "reference/track-metadata",
-        "reference/get-prompts"
+        "reference/get-prompts",
+        "reference/templates-get"
       ]
     }
   ],

--- a/openapi.json
+++ b/openapi.json
@@ -139,6 +139,57 @@
           }
         }
       }
+    },
+    "/prompt-templates/{identifier}": {
+      "post": {
+        "tags": ["prompt-templates"],
+        "summary": "Get Prompt Template by ID",
+        "operationId": "get_prompt_templates__identifier__post",
+        "parameters": [
+          {
+            "name": "identifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "anyOf": [{ "type": "string" }, { "type": "integer" }],
+              "title": "Identifier"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  { "$ref": "#/components/schemas/GetPromptTemplate" },
+                  { "type": "null" }
+                ],
+                "title": "Body"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetPromptTemplateResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -589,6 +640,412 @@
             "required": ["provider", "name"]
           }
         }
+      },
+      "GetPromptTemplate": {
+        "properties": {
+          "version": {
+            "anyOf": [
+              { "type": "integer", "exclusiveMinimum": 0.0 },
+              { "type": "null" }
+            ],
+            "title": "Version"
+          },
+          "workspace_id": {
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "title": "Workspace Id"
+          },
+          "label": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Label"
+          },
+          "provider": {
+            "anyOf": [
+              { "type": "string", "enum": ["openai", "anthropic"] },
+              { "type": "null" }
+            ],
+            "title": "Provider"
+          },
+          "input_variables": {
+            "anyOf": [
+              {
+                "additionalProperties": { "type": "string" },
+                "type": "object"
+              },
+              { "type": "null" }
+            ],
+            "title": "Input Variables"
+          }
+        },
+        "type": "object",
+        "title": "GetPromptTemplate"
+      },
+      "CompletionPrompt": {
+        "properties": {
+          "content": {
+            "items": {
+              "oneOf": [
+                { "$ref": "#/components/schemas/TextContent" },
+                { "$ref": "#/components/schemas/ImageContent" }
+              ],
+              "discriminator": {
+                "propertyName": "type",
+                "mapping": {
+                  "image_url": "#/components/schemas/ImageContent",
+                  "text": "#/components/schemas/TextContent"
+                }
+              }
+            },
+            "type": "array",
+            "title": "Content"
+          },
+          "input_variables": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Input Variables",
+            "default": []
+          },
+          "template_format": {
+            "type": "string",
+            "enum": ["f-string", "jinja2"],
+            "title": "Template Format",
+            "default": "f-string"
+          },
+          "type": {
+            "const": "completion",
+            "title": "Type",
+            "default": "completion"
+          },
+          "prefill": {
+            "anyOf": [
+              { "$ref": "#/components/schemas/TextContent" },
+              { "type": "null" }
+            ]
+          },
+          "system": {
+            "anyOf": [
+              { "$ref": "#/components/schemas/TextContent" },
+              { "type": "null" }
+            ]
+          }
+        },
+        "additionalProperties": true,
+        "type": "object",
+        "required": ["content"],
+        "title": "CompletionPrompt"
+      },
+      "TextContent": {
+        "properties": {
+          "type": { "const": "text", "title": "Type", "default": "text" },
+          "text": { "type": "string", "title": "Text" }
+        },
+        "type": "object",
+        "required": ["text"],
+        "title": "TextContent"
+      },
+      "ImageURL": {
+        "properties": {
+          "url": { "type": "string", "title": "Url" },
+          "detail": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "required": ["url"],
+        "title": "ImageURL"
+      },
+      "ImageContent": {
+        "properties": {
+          "type": {
+            "const": "image_url",
+            "title": "Type",
+            "default": "image_url"
+          },
+          "image_url": { "$ref": "#/components/schemas/ImageURL" }
+        },
+        "type": "object",
+        "required": ["image_url"],
+        "title": "ImageContent"
+      },
+      "SystemMessage": {
+        "properties": {
+          "input_variables": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Input Variables",
+            "default": []
+          },
+          "template_format": {
+            "type": "string",
+            "enum": ["f-string", "jinja2"],
+            "title": "Template Format",
+            "default": "f-string"
+          },
+          "content": {
+            "items": {
+              "oneOf": [
+                { "$ref": "#/components/schemas/TextContent" },
+                { "$ref": "#/components/schemas/ImageContent" }
+              ],
+              "discriminator": {
+                "propertyName": "type",
+                "mapping": {
+                  "image_url": "#/components/schemas/ImageContent",
+                  "text": "#/components/schemas/TextContent"
+                }
+              }
+            },
+            "type": "array",
+            "title": "Content"
+          },
+          "role": { "const": "system", "title": "Role", "default": "system" },
+          "name": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "required": ["content"],
+        "title": "SystemMessage"
+      },
+      "UserMessage": {
+        "properties": {
+          "input_variables": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Input Variables",
+            "default": []
+          },
+          "template_format": {
+            "type": "string",
+            "enum": ["f-string", "jinja2"],
+            "title": "Template Format",
+            "default": "f-string"
+          },
+          "content": {
+            "items": {
+              "oneOf": [
+                { "$ref": "#/components/schemas/TextContent" },
+                { "$ref": "#/components/schemas/ImageContent" }
+              ],
+              "discriminator": {
+                "propertyName": "type",
+                "mapping": {
+                  "image_url": "#/components/schemas/ImageContent",
+                  "text": "#/components/schemas/TextContent"
+                }
+              }
+            },
+            "type": "array",
+            "title": "Content"
+          },
+          "role": { "const": "user", "title": "Role", "default": "user" },
+          "name": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "required": ["content"],
+        "title": "UserMessage"
+      },
+      "AssistantMessage": {
+        "properties": {
+          "input_variables": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Input Variables",
+            "default": []
+          },
+          "template_format": {
+            "type": "string",
+            "enum": ["f-string", "jinja2"],
+            "title": "Template Format",
+            "default": "f-string"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "items": {
+                  "oneOf": [
+                    { "$ref": "#/components/schemas/TextContent" },
+                    { "$ref": "#/components/schemas/ImageContent" }
+                  ],
+                  "discriminator": {
+                    "propertyName": "type",
+                    "mapping": {
+                      "image_url": "#/components/schemas/ImageContent",
+                      "text": "#/components/schemas/TextContent"
+                    }
+                  }
+                },
+                "type": "array"
+              },
+              { "type": "null" }
+            ],
+            "title": "Content"
+          },
+          "role": {
+            "const": "assistant",
+            "title": "Role",
+            "default": "assistant"
+          },
+          "function_call": {
+            "anyOf": [
+              { "$ref": "#/components/schemas/FunctionCall" },
+              { "type": "null" }
+            ]
+          },
+          "name": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "title": "AssistantMessage"
+      },
+      "FunctionMessage": {
+        "properties": {
+          "input_variables": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Input Variables",
+            "default": []
+          },
+          "template_format": {
+            "type": "string",
+            "enum": ["f-string", "jinja2"],
+            "title": "Template Format",
+            "default": "f-string"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "items": {
+                  "oneOf": [
+                    { "$ref": "#/components/schemas/TextContent" },
+                    { "$ref": "#/components/schemas/ImageContent" }
+                  ],
+                  "discriminator": {
+                    "propertyName": "type",
+                    "mapping": {
+                      "image_url": "#/components/schemas/ImageContent",
+                      "text": "#/components/schemas/TextContent"
+                    }
+                  }
+                },
+                "type": "array"
+              },
+              { "type": "null" }
+            ],
+            "title": "Content"
+          },
+          "role": {
+            "const": "function",
+            "title": "Role",
+            "default": "function"
+          },
+          "name": { "type": "string", "title": "Name" }
+        },
+        "type": "object",
+        "required": ["name"],
+        "title": "FunctionMessage"
+      },
+      "MessageFunctionCall": {
+        "properties": { "name": { "type": "string", "title": "Name" } },
+        "type": "object",
+        "required": ["name"],
+        "title": "MessageFunctionCall"
+      },
+      "ChatPrompt": {
+        "properties": {
+          "messages": {
+            "items": {
+              "oneOf": [
+                { "$ref": "#/components/schemas/SystemMessage" },
+                { "$ref": "#/components/schemas/UserMessage" },
+                { "$ref": "#/components/schemas/AssistantMessage" },
+                { "$ref": "#/components/schemas/FunctionMessage" }
+              ],
+              "discriminator": {
+                "propertyName": "role",
+                "mapping": {
+                  "assistant": "#/components/schemas/AssistantMessage",
+                  "function": "#/components/schemas/FunctionMessage",
+                  "system": "#/components/schemas/SystemMessage",
+                  "user": "#/components/schemas/UserMessage"
+                }
+              }
+            },
+            "type": "array",
+            "title": "Messages"
+          },
+          "functions": {
+            "anyOf": [
+              {
+                "items": { "$ref": "#/components/schemas/Function" },
+                "type": "array"
+              },
+              { "type": "null" }
+            ],
+            "title": "Functions"
+          },
+          "function_call": {
+            "anyOf": [
+              { "type": "string" },
+              { "$ref": "#/components/schemas/MessageFunctionCall" },
+              { "type": "null" }
+            ],
+            "title": "Function Call"
+          },
+          "type": { "const": "chat", "title": "Type", "default": "chat" },
+          "input_variables": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Input Variables",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": ["messages"],
+        "title": "ChatPrompt"
+      },
+      "GetPromptTemplateResponse": {
+        "properties": {
+          "id": { "type": "integer", "title": "Id" },
+          "prompt_name": { "type": "string", "title": "Prompt Name" },
+          "prompt_template": {
+            "oneOf": [
+              { "$ref": "#/components/schemas/CompletionPrompt" },
+              { "$ref": "#/components/schemas/ChatPrompt" }
+            ],
+            "title": "Prompt Template",
+            "discriminator": {
+              "propertyName": "type",
+              "mapping": {
+                "chat": "#/components/schemas/ChatPrompt",
+                "completion": "#/components/schemas/CompletionPrompt"
+              }
+            }
+          },
+          "metadata": {
+            "anyOf": [
+              { "$ref": "#/components/schemas/Metadata" },
+              { "type": "null" }
+            ]
+          },
+          "commit_message": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Commit Message"
+          },
+          "llm_kwargs": {
+            "anyOf": [{ "type": "object" }, { "type": "null" }],
+            "title": "Llm Kwargs"
+          }
+        },
+        "type": "object",
+        "required": ["id", "prompt_name", "prompt_template"],
+        "title": "GetPromptTemplateResponse"
       }
     }
   }

--- a/reference/get-prompt-template.mdx
+++ b/reference/get-prompt-template.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Get Prompt Template"
+title: "Get Prompt Template (Depcrecated)"
 openapi: "GET /rest/get-prompt-template"
 ---
 

--- a/reference/get-prompt-template.mdx
+++ b/reference/get-prompt-template.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Get Prompt Template (Depcrecated)"
+title: "Get Prompt Template (Deprecated)"
 openapi: "GET /rest/get-prompt-template"
 ---
 

--- a/reference/get-prompts.mdx
+++ b/reference/get-prompts.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Get Prompt Templates"
+title: "Get All Prompt Templates"
 openapi: "GET /rest/prompts"
 ---
 

--- a/reference/rest-api-reference.mdx
+++ b/reference/rest-api-reference.mdx
@@ -5,7 +5,7 @@ icon: "webhook"
 
 Right now, the primary way to access PromptLayer is through our Python wrapper library that can be installed with `pip install promptlayer`.
 
-The Python library is a wrapper over our REST API. If you use another language, like Javascript, just interact directly with the API. 
+The Python library is a wrapper over our REST API. If you use another language, like Javascript, just interact directly with the API.
 
 Here are the calls you can make via our REST API (`https://api.promptlayer.com/rest`):
 
@@ -15,4 +15,4 @@ Here are the calls you can make via our REST API (`https://api.promptlayer.com/r
 4. [Track Score](/reference/track-score)
 5. [Track Prompt](/reference/track-prompt)
 6. [Track Metadata](/reference/track-metadata)
-7. [Get Prompts](/reference/get-prompts)
+7. [Get All Prompt Templates](/reference/get-prompts)

--- a/reference/rest-api-reference.mdx
+++ b/reference/rest-api-reference.mdx
@@ -10,7 +10,7 @@ The Python library is a wrapper over our REST API. If you use another language, 
 Here are the calls you can make via our REST API (`https://api.promptlayer.com/rest`):
 
 1. [Track Request](/reference/track-request)
-2. [Get Prompt Template](/reference/get-prompt-template)
+2. [Get Prompt Template (Deprecated)](/reference/get-prompt-template)
 3. [Publish Prompt Template](/reference/publish-prompt-template)
 4. [Track Score](/reference/track-score)
 5. [Track Prompt](/reference/track-prompt)

--- a/reference/templates-get.mdx
+++ b/reference/templates-get.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Get Prompt Template (Identifier)"
+title: "Get Prompt Template"
 openapi: "POST /prompt-templates/{identifier}"
 ---
 

--- a/reference/templates-get.mdx
+++ b/reference/templates-get.mdx
@@ -1,0 +1,6 @@
+---
+title: "Get Prompt Template (Identifier)"
+openapi: "POST /prompt-templates/{identifier}"
+---
+
+Get a prompt template by identifier.


### PR DESCRIPTION
This pull request adds a new endpoint for retrieving prompt templates by identifier. The endpoint is `/prompt-templates/{identifier}` and can be accessed with a POST request. This allows users to fetch prompt templates using the identifier as a parameter. The implementation includes updates to the Python SDK and JavaScript SDK to demonstrate how to use the new endpoint.