### PR TITLE
86 - Fix request id type in track-request

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -92,7 +92,7 @@
                       "type": "string"
                     },
                     "request_id": {
-                      "type": "string",
+                      "type": "integer",
                       "description": "The unique identifier for the tracked request."
                     }
                   },
@@ -1906,7 +1906,11 @@
                 "prompt_version_number": { "type": "integer" },
                 "release_label": { "type": "string" }
               },
-              "required": ["prompt_version_id", "prompt_version_number", "release_label"]
+              "required": [
+                "prompt_version_id",
+                "prompt_version_number",
+                "release_label"
+              ]
             },
             "title": "Release Labels"
           }


### PR DESCRIPTION
This pull request fixes the request id type in the track-request endpoint. Previously, the request id was defined as a string, but it should be an integer. This PR updates the request id type to integer to ensure accurate tracking of requests.