### PR TITLE
88 - Update docs for promptlayer run

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -63,6 +63,14 @@
                   "api_key": {
                     "type": "string",
                     "description": "The API key for authentication."
+                  },
+                  "group_id": {
+                    "type": "integer",
+                    "description": "The ID of the group that you want to associate with this request. This is useful for tracking requests that are part of a group, such as a conversation or a session."
+                  },
+                  "return_data": {
+                    "type": "boolean",
+                    "description": "If you want to return the data that is associated with the request, set this to `true`. This will return the request_id and the request data."
                   }
                 },
                 "required": [

--- a/openapi.json
+++ b/openapi.json
@@ -68,7 +68,7 @@
                     "type": "integer",
                     "description": "The ID of the group that you want to associate with this request. This is useful for tracking requests that are part of a group, such as a conversation or a session."
                   },
-                  "return_data": {
+                  "return_prompt_blueprint": {
                     "type": "boolean",
                     "description": "If you want to return the data that is associated with the request, set this to `true`. This will return the request_id and the request data."
                   }
@@ -102,6 +102,10 @@
                     "request_id": {
                       "type": "integer",
                       "description": "The unique identifier for the tracked request."
+                    },
+                    "prompt_blueprint": {
+                      "type": "object",
+                      "description": "The prompt blueprint that was used for this request."
                     }
                   },
                   "required": ["success", "message", "request_id"]

--- a/reference/templates-get.mdx
+++ b/reference/templates-get.mdx
@@ -5,4 +5,4 @@ openapi: "POST /prompt-templates/{prompt_name}"
 
 Retrieve a prompt template using it's `prompt_name`. Optionally, specify `version` (version number) or `label` (release label like "prod") to retrieve a specific version. If not specified, the latest version is returned.
 
-You can also specify a `provider` to return LLM-specific arguments that can be passed directly into your LLM client. To format the template with input variables, use `input_variables`.
+PromptLayer will try to read `provider` from the parameters you attach to the prompt template. You can also specify a `provider` to return LLM-specific arguments that can be passed directly into your LLM client. To format the template with input variables, use `input_variables`.

--- a/reference/templates-get.mdx
+++ b/reference/templates-get.mdx
@@ -5,4 +5,4 @@ openapi: "POST /prompt-templates/{prompt_name}"
 
 Retrieve a prompt template using it's `prompt_name`. Optionally, specify `version` (version number) or `label` (release label like "prod") to retrieve a specific version. If not specified, the latest version is returned.
 
-PromptLayer will try to read `provider` from the parameters you attach to the prompt template. You can also specify a `provider` to return LLM-specific arguments that can be passed directly into your LLM client. To format the template with input variables, use `input_variables`.
+PromptLayer will try to read the model provider from the parameters you attached to the prompt template. You can optionally pass in a `provider` to override the one set in the Prompt Registry. This will return LLM-specific arguments that can be passed directly into your LLM client. To format the template with input variables, use `input_variables`.


### PR DESCRIPTION
This pull request adds two new attributes, `group_id` and `return_data`, to the request endpoint. The `group_id` attribute allows for tracking requests that are part of a group, such as a conversation or a session. The `return_data` attribute, when set to `true`, returns the request ID and associated data. Additionally, the prompt section has been updated to clarify the usage of the `provider` parameter.