### PR TITLE
Add log-request endpoint and documentation

### DIFF
--- a/features/prompt-history/custom-logging.mdx
+++ b/features/prompt-history/custom-logging.mdx
@@ -1,0 +1,176 @@
+---
+title: "Custom Logging"
+icon: "brackets-curly"
+---
+
+PromptLayer allows you to log requests made via custom LLM providers. This is useful for logging requests that are not made via the PromptLayer SDK.
+
+<CodeGroup>
+```python Python
+from huggingface_hub import InferenceClient
+from promptlayer import PromptLayer
+from datetime import datetime
+
+PROMPTLAYER_API_KEY = "pl_..."
+promptlayer = PromptLayer(api_key=PROMPTLAYER_API_KEY)
+
+prompt_name = "weather"
+prompt_version_number = 30
+prompt_input_variables = {"city": "Paris"}
+template = promptlayer.templates.get(
+    prompt_name,
+    {"version": prompt_version_number, "input_variables": prompt_input_variables},
+)
+
+messages = [
+    message
+    if isinstance(message["content"], str)
+    else {**message, "content": message["content"][0]["text"]}
+    for message in template["llm_kwargs"]["messages"]
+]
+parameters = template["metadata"]["model"]["parameters"]
+
+provider = "meta-llama"
+model = "Meta-Llama-3-8B-Instruct"
+
+HF_TOKEN = "hf_..."
+client = InferenceClient(
+    f"{provider}/{model}",
+    api_key=HF_TOKEN,
+)
+request_start_time = datetime.now().timestamp()
+response = client.chat_completion(messages=messages, **parameters)
+request_end_time = datetime.now().timestamp()
+
+input = {
+    "type": "chat",
+    "messages": [
+        {**message, "content": [{"type": "text", "text": message["content"]}]}
+        for message in messages
+    ],
+}
+
+output = {
+    "type": "chat",
+    "messages": [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "text",
+                    "text": response.choices[0].message.content,
+                }
+            ],
+        }
+    ],
+}
+
+request_log = promptlayer.log_request(
+    provider=provider,
+    model=model,
+    input=input,
+    output=output,
+    request_start_time=request_start_time,
+    parameters=parameters,
+    request_end_time=request_end_time,
+    prompt_name=prompt_name,
+    prompt_version_number=prompt_version_number,
+    prompt_input_variables=prompt_input_variables,
+    input_tokens=response.usage.prompt_tokens,
+    output_tokens=response.usage.completion_tokens,
+    function_name="inference",
+    tags=["chat"],
+    metadata={"model": "custom-model"},
+    price=0.00045,
+    score=70,
+)
+print(request_log["id"])
+```
+
+```javascript JavaScript
+import { PromptLayer } from "@/index";
+import { HfInference } from "@huggingface/inference";
+
+const PROMPTLAYER_API_KEY = "pl_...";
+const promptLayer = new PromptLayer({ apiKey: PROMPTLAYER_API_KEY });
+
+const main = async () => {
+  const prompt_name = "weather";
+  const prompt_version_number = 30;
+  const prompt_input_variables = { city: "Paris" };
+  const template = await promptLayer.templates.get(prompt_name, {
+    version: prompt_version_number,
+    input_variables: prompt_input_variables,
+  });
+
+  const messages = template.llm_kwargs.messages.map((message) =>
+    typeof message.content === "string"
+      ? message
+      : { ...message, content: message.content[0].text }
+  );
+
+  const parameters = template.metadata.model.parameters;
+
+  const provider = "meta-llama";
+  const model = "Meta-Llama-3-8B-Instruct";
+
+  const HF_TOKEN = "hf_...";
+
+  const client = new HfInference(HF_TOKEN);
+  const request_start_time = new Date().getTime();
+  const response = await client.chatCompletion({
+    model: `${provider}/${model}`,
+    messages,
+    ...parameters,
+  });
+  const request_end_time = new Date().getTime();
+
+  const input = {
+    type: "chat",
+    messages: messages.map((message) => ({
+      ...message,
+      content: [{ type: "text", text: message.content }],
+    })),
+  };
+
+  const output = {
+    type: "chat",
+    messages: [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: response.choices[0].message.content,
+          },
+        ],
+      },
+    ],
+  };
+
+  const request_log = await promptLayer.logRequest({
+    provider,
+    model,
+    input,
+    output,
+    request_start_time,
+    parameters,
+    request_end_time,
+    prompt_name,
+    prompt_version_number,
+    prompt_input_variables,
+    input_tokens: response.usage.prompt_tokens,
+    output_tokens: response.usage.completion_tokens,
+    function_name: "inference",
+    tags: ["chat"],
+    metadata: { model },
+    price: 0.00045,
+    score: 70,
+  });
+
+  console.log(request_log.id);
+};
+
+main();
+```
+</CodeGroup>

--- a/mint.json
+++ b/mint.json
@@ -61,7 +61,8 @@
             "features/prompt-history/metadata",
             "features/prompt-history/scoring-requests",
             "features/prompt-history/tracking-templates",
-            "features/prompt-history/groups"
+            "features/prompt-history/groups",
+            "features/prompt-history/custom-logging"
           ],
           "icon": "cassette-tape"
         },
@@ -117,7 +118,8 @@
         "reference/dataset-from-filter-params",
         "reference/delete-datasets-by-name",
         "reference/create-reports",
-        "reference/delete-reports-by-name"
+        "reference/delete-reports-by-name",
+        "reference/log-request"
       ]
     }
   ],

--- a/openapi.json
+++ b/openapi.json
@@ -1235,6 +1235,70 @@
           }
         }
       }
+    },
+    "/log-request": {
+      "post": {
+        "tags": ["request"],
+        "summary": "Log Request",
+        "operationId": "logRequest",
+        "parameters": [
+          {
+            "name": "X-API-KEY",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "X-Api-Key"
+            },
+            "description": "API key to authorize the operation."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LogRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LogRequestResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    { "$ref": "#/components/schemas/BadRequestError" },
+                    { "$ref": "#/components/schemas/ValidationError" }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -1725,56 +1789,63 @@
         "title": "GetPromptTemplate"
       },
       "CompletionPrompt": {
+        "additionalProperties": true,
         "properties": {
           "content": {
             "items": {
-              "oneOf": [
-                { "$ref": "#/components/schemas/TextContent" },
-                { "$ref": "#/components/schemas/ImageContent" }
-              ],
               "discriminator": {
-                "propertyName": "type",
                 "mapping": {
                   "image_url": "#/components/schemas/ImageContent",
                   "text": "#/components/schemas/TextContent"
-                }
-              }
+                },
+                "propertyName": "type"
+              },
+              "oneOf": [
+                { "$ref": "#/components/schemas/TextContent" },
+                { "$ref": "#/components/schemas/ImageContent" }
+              ]
             },
-            "type": "array",
-            "title": "Content"
+            "title": "Content",
+            "type": "array"
           },
           "input_variables": {
+            "default": [],
             "items": { "type": "string" },
-            "type": "array",
             "title": "Input Variables",
-            "default": []
+            "type": "array"
           },
           "template_format": {
-            "type": "string",
+            "default": "f-string",
             "enum": ["f-string", "jinja2"],
             "title": "Template Format",
-            "default": "f-string"
+            "type": "string"
           },
           "type": {
             "const": "completion",
+            "default": "completion",
+            "enum": ["completion"],
             "title": "Type",
-            "default": "completion"
+            "type": "string"
           }
         },
-        "additionalProperties": true,
-        "type": "object",
         "required": ["content"],
-        "title": "CompletionPrompt",
-        "description": "Completion Prompt Template"
+        "title": "CompletionTemplate",
+        "type": "object"
       },
       "TextContent": {
         "properties": {
-          "type": { "const": "text", "title": "Type", "default": "text" },
-          "text": { "type": "string", "title": "Text" }
+          "type": {
+            "const": "text",
+            "default": "text",
+            "enum": ["text"],
+            "title": "Type",
+            "type": "string"
+          },
+          "text": { "title": "Text", "type": "string" }
         },
-        "type": "object",
         "required": ["text"],
-        "title": "TextContent"
+        "title": "TextContent",
+        "type": "object"
       },
       "ImageURL": {
         "properties": {
@@ -1792,14 +1863,21 @@
         "properties": {
           "type": {
             "const": "image_url",
+            "default": "image_url",
+            "enum": ["image_url"],
             "title": "Type",
-            "default": "image_url"
+            "type": "string"
           },
-          "image_url": { "$ref": "#/components/schemas/ImageURL" }
+          "image_url": { "$ref": "#/components/schemas/ImageURL" },
+          "image_variable": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "default": null,
+            "title": "Image Variable"
+          }
         },
-        "type": "object",
         "required": ["image_url"],
-        "title": "ImageContent"
+        "title": "ImageContent",
+        "type": "object"
       },
       "SystemMessage": {
         "properties": {
@@ -2008,26 +2086,28 @@
         "properties": {
           "messages": {
             "items": {
+              "discriminator": {
+                "mapping": {
+                  "assistant": "#/components/schemas/AssistantMessage",
+                  "function": "#/components/schemas/FunctionMessage",
+                  "placeholder": "#/components/schemas/PlaceholderMessage",
+                  "system": "#/components/schemas/SystemMessage",
+                  "tool": "#/components/schemas/ToolMessage",
+                  "user": "#/components/schemas/UserMessage"
+                },
+                "propertyName": "role"
+              },
               "oneOf": [
                 { "$ref": "#/components/schemas/SystemMessage" },
                 { "$ref": "#/components/schemas/UserMessage" },
                 { "$ref": "#/components/schemas/AssistantMessage" },
                 { "$ref": "#/components/schemas/FunctionMessage" },
-                { "$ref": "#/components/schemas/ToolMessage" }
-              ],
-              "discriminator": {
-                "propertyName": "role",
-                "mapping": {
-                  "assistant": "#/components/schemas/AssistantMessage",
-                  "function": "#/components/schemas/FunctionMessage",
-                  "system": "#/components/schemas/SystemMessage",
-                  "user": "#/components/schemas/UserMessage",
-                  "tool": "#/components/schemas/ToolMessage"
-                }
-              }
+                { "$ref": "#/components/schemas/ToolMessage" },
+                { "$ref": "#/components/schemas/PlaceholderMessage" }
+              ]
             },
-            "type": "array",
-            "title": "Messages"
+            "title": "Messages",
+            "type": "array"
           },
           "functions": {
             "anyOf": [
@@ -2037,26 +2117,8 @@
               },
               { "type": "null" }
             ],
-            "title": "Functions",
-            "deprecated": true,
-            "description": "This field is deprecated. Please use `tools` to specify tools."
-          },
-          "function_call": {
-            "anyOf": [
-              { "type": "string" },
-              { "$ref": "#/components/schemas/MessageFunctionCall" },
-              { "type": "null" }
-            ],
-            "title": "Function Call",
-            "deprecated": true,
-            "description": "This field is deprecated. Please use `tool_choice` field to specify tool choice."
-          },
-          "type": { "const": "chat", "title": "Type", "default": "chat" },
-          "input_variables": {
-            "items": { "type": "string" },
-            "type": "array",
-            "title": "Input Variables",
-            "default": []
+            "default": null,
+            "title": "Functions"
           },
           "tools": {
             "anyOf": [
@@ -2066,7 +2128,17 @@
               },
               { "type": "null" }
             ],
+            "default": null,
             "title": "Tools"
+          },
+          "function_call": {
+            "anyOf": [
+              { "type": "string" },
+              { "$ref": "#/components/schemas/MessageFunctionCall" },
+              { "type": "null" }
+            ],
+            "default": null,
+            "title": "Function Call"
           },
           "tool_choice": {
             "anyOf": [
@@ -2074,13 +2146,26 @@
               { "$ref": "#/components/schemas/ChatToolChoice" },
               { "type": "null" }
             ],
+            "default": null,
             "title": "Tool Choice"
+          },
+          "type": {
+            "const": "chat",
+            "default": "chat",
+            "enum": ["chat"],
+            "title": "Type",
+            "type": "string"
+          },
+          "input_variables": {
+            "default": [],
+            "items": { "type": "string" },
+            "title": "Input Variables",
+            "type": "array"
           }
         },
-        "type": "object",
         "required": ["messages"],
-        "title": "ChatPrompt",
-        "description": "Chat Prompt Template"
+        "title": "ChatTemplate",
+        "type": "object"
       },
       "GetPromptTemplateResponse": {
         "properties": {
@@ -2370,6 +2455,206 @@
           "total"
         ],
         "title": "ListPromptTemplates"
+      },
+      "PlaceholderMessage": {
+        "properties": {
+          "input_variables": {
+            "default": [],
+            "items": { "type": "string" },
+            "title": "Input Variables",
+            "type": "array"
+          },
+          "template_format": {
+            "default": "f-string",
+            "enum": ["f-string", "jinja2"],
+            "title": "Template Format",
+            "type": "string"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "items": {
+                  "discriminator": {
+                    "mapping": {
+                      "image_url": "#/components/schemas/ImageContent",
+                      "text": "#/components/schemas/TextContent"
+                    },
+                    "propertyName": "type"
+                  },
+                  "oneOf": [
+                    { "$ref": "#/components/schemas/TextContent" },
+                    { "$ref": "#/components/schemas/ImageContent" }
+                  ]
+                },
+                "type": "array"
+              },
+              { "type": "null" }
+            ],
+            "default": null,
+            "title": "Content"
+          },
+          "raw_request_display_role": {
+            "default": "",
+            "title": "Raw Request Display Role",
+            "type": "string"
+          },
+          "role": {
+            "const": "placeholder",
+            "default": "placeholder",
+            "enum": ["placeholder"],
+            "title": "Role",
+            "type": "string"
+          },
+          "name": { "title": "Name", "type": "string" }
+        },
+        "required": ["name"],
+        "title": "PlaceholderMessage",
+        "type": "object"
+      },
+      "LogRequest": {
+        "properties": {
+          "provider": { "title": "Provider", "type": "string" },
+          "model": { "title": "Model", "type": "string" },
+          "input": {
+            "discriminator": {
+              "mapping": {
+                "chat": "#/components/schemas/ChatPrompt",
+                "completion": "#/components/schemas/CompletionPrompt"
+              },
+              "propertyName": "type"
+            },
+            "oneOf": [
+              { "$ref": "#/components/schemas/CompletionPrompt" },
+              { "$ref": "#/components/schemas/ChatPrompt" }
+            ],
+            "title": "Input"
+          },
+          "output": {
+            "discriminator": {
+              "mapping": {
+                "chat": "#/components/schemas/ChatPrompt",
+                "completion": "#/components/schemas/CompletionPrompt"
+              },
+              "propertyName": "type"
+            },
+            "oneOf": [
+              { "$ref": "#/components/schemas/CompletionPrompt" },
+              { "$ref": "#/components/schemas/ChatPrompt" }
+            ],
+            "title": "Output"
+          },
+          "request_start_time": {
+            "format": "date-time",
+            "title": "Request Start Time",
+            "type": "string"
+          },
+          "request_end_time": {
+            "format": "date-time",
+            "title": "Request End Time",
+            "type": "string"
+          },
+          "parameters": {
+            "default": {},
+            "title": "Parameters",
+            "type": "object"
+          },
+          "tags": {
+            "default": [],
+            "items": { "maxLength": 512, "type": "string" },
+            "title": "Tags",
+            "type": "array"
+          },
+          "metadata": {
+            "additionalProperties": { "type": "string" },
+            "default": {},
+            "title": "Metadata",
+            "type": "object"
+          },
+          "prompt_name": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "default": null,
+            "title": "Prompt Name"
+          },
+          "prompt_version_number": {
+            "anyOf": [
+              { "exclusiveMinimum": 0, "type": "integer" },
+              { "type": "null" }
+            ],
+            "default": null,
+            "title": "Prompt Version Number"
+          },
+          "prompt_input_variables": {
+            "default": {},
+            "title": "Prompt Input Variables",
+            "type": "object"
+          },
+          "input_tokens": {
+            "default": 0,
+            "minimum": 0,
+            "title": "Input Tokens",
+            "type": "integer"
+          },
+          "output_tokens": {
+            "default": 0,
+            "minimum": 0,
+            "title": "Output Tokens",
+            "type": "integer"
+          },
+          "price": {
+            "default": 0.0,
+            "minimum": 0.0,
+            "title": "Price",
+            "type": "number"
+          },
+          "function_name": {
+            "default": "",
+            "title": "Function Name",
+            "type": "string"
+          },
+          "score": {
+            "default": 0,
+            "maximum": 100,
+            "minimum": 0,
+            "title": "Score",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "provider",
+          "model",
+          "input",
+          "output",
+          "request_start_time",
+          "request_end_time"
+        ],
+        "title": "LogRequest",
+        "type": "object"
+      },
+      "LogRequestResponse": {
+        "properties": {
+          "id": { "title": "Id", "type": "integer" },
+          "prompt_version": {
+            "$ref": "#/components/schemas/PromptVersion"
+          }
+        },
+        "required": ["id", "prompt_version"],
+        "title": "LogRequestResponse",
+        "type": "object"
+      },
+      "BadRequestError": {
+        "properties": {
+          "success": {
+            "const": false,
+            "default": false,
+            "enum": [false],
+            "title": "Success",
+            "type": "boolean"
+          },
+          "message": { "title": "Message", "type": "string" }
+        },
+        "required": ["message"],
+        "title": "BadRequestError",
+        "type": "object"
       }
     }
   }

--- a/reference/log-request.mdx
+++ b/reference/log-request.mdx
@@ -1,0 +1,6 @@
+---
+title: "Log Request"
+openapi: "POST /log-request"
+---
+
+Log a request to the system. This is useful for logging requests from custom LLM providers.


### PR DESCRIPTION
This pull request adds a new endpoint and documentation for logging requests to the system. The new endpoint, `POST /log-request`, allows users to log requests from custom LLM providers. This is useful for logging requests that are not made via the PromptLayer SDK. The documentation provides examples in Python and JavaScript on how to use the new endpoint to log requests.