### PR TITLE
Add prompt_id parameter to custom logging

### DIFF
--- a/features/prompt-history/custom-logging.mdx
+++ b/features/prompt-history/custom-logging.mdx
@@ -29,6 +29,7 @@ When logging a custom request, you can use the following parameters (see [API Re
 - **`request_start_time`**: Timestamp when the request started
 - **`request_end_time`**: Timestamp when the response was received
 - **`prompt_name`**: Name of the prompt template if using one from PromptLayer
+- **`prompt_id`**: Unique identifier for the prompt template
 - **`prompt_version_number`**: Version number of the prompt template
 - **`prompt_input_variables`**: Variables used in the prompt template
 - **`input_tokens`**: Number of input tokens used

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,9 @@
   "paths": {
     "/prompt-templates/{identifier}": {
       "post": {
-        "tags": ["prompt-templates"],
+        "tags": [
+          "prompt-templates"
+        ],
         "summary": "Get Prompt Template by ID",
         "operationId": "get_prompt_templates__prompt_identifier__post",
         "parameters": [
@@ -74,7 +76,10 @@
     },
     "/prompt-templates/{identifier}/labels": {
       "get": {
-        "tags": ["prompt-templates", "release-labels"],
+        "tags": [
+          "prompt-templates",
+          "release-labels"
+        ],
         "summary": "Get Prompt Template Labels",
         "operationId": "get_prompt_templates_labels_prompt_identifier__post",
         "parameters": [
@@ -117,7 +122,10 @@
     },
     "/prompts/{prompt_id}/label": {
       "post": {
-        "tags": ["prompts", "labels"],
+        "tags": [
+          "prompts",
+          "labels"
+        ],
         "summary": "Create a new label for a prompt",
         "operationId": "create_prompt_label",
         "parameters": [
@@ -154,7 +162,10 @@
                     "type": "string"
                   }
                 },
-                "required": ["prompt_version_number", "name"]
+                "required": [
+                  "prompt_version_number",
+                  "name"
+                ]
               }
             }
           }
@@ -200,7 +211,10 @@
     },
     "/prompt-labels/{prompt_label_id}": {
       "patch": {
-        "tags": ["prompt-templates", "release-labels"],
+        "tags": [
+          "prompt-templates",
+          "release-labels"
+        ],
         "summary": "Move Prompt Template Labels",
         "operationId": "prompt_templates_labels_prompt_label_id__patch",
         "parameters": [
@@ -234,7 +248,9 @@
                     "type": "integer"
                   }
                 },
-                "required": ["prompt_version_number"]
+                "required": [
+                  "prompt_version_number"
+                ]
               }
             }
           }
@@ -278,7 +294,10 @@
         }
       },
       "delete": {
-        "tags": ["prompt-templates", "release-labels"],
+        "tags": [
+          "prompt-templates",
+          "release-labels"
+        ],
         "summary": "Delete Prompt Template Label",
         "operationId": "delete_prompt_templates_labels_prompt_label_id",
         "parameters": [
@@ -317,7 +336,10 @@
     },
     "/rest/prompt-templates": {
       "post": {
-        "tags": ["rest", "prompt-templates"],
+        "tags": [
+          "rest",
+          "prompt-templates"
+        ],
         "summary": "Publish Prompt Template",
         "operationId": "publish_prompt_template_rest_prompt_templates_post",
         "parameters": [
@@ -369,7 +391,9 @@
       "post": {
         "summary": "Track Metadata",
         "operationId": "trackMetadata",
-        "tags": ["metadata"],
+        "tags": [
+          "metadata"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -391,7 +415,11 @@
                     "description": "A dictionary of metadata items to associate with the request. Can include session_ids, user_ids, location, etc."
                   }
                 },
-                "required": ["api_key", "request_id", "metadata"]
+                "required": [
+                  "api_key",
+                  "request_id",
+                  "metadata"
+                ]
               }
             }
           }
@@ -411,7 +439,10 @@
                       "type": "string"
                     }
                   },
-                  "required": ["success", "message"]
+                  "required": [
+                    "success",
+                    "message"
+                  ]
                 }
               }
             }
@@ -429,7 +460,9 @@
       "post": {
         "summary": "Track Group",
         "operationId": "trackGroup",
-        "tags": ["group"],
+        "tags": [
+          "group"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -450,7 +483,11 @@
                     "description": "The unique identifier for the group to be associated with the request."
                   }
                 },
-                "required": ["api_key", "request_id", "group_id"]
+                "required": [
+                  "api_key",
+                  "request_id",
+                  "group_id"
+                ]
               }
             }
           }
@@ -470,7 +507,10 @@
                       "type": "string"
                     }
                   },
-                  "required": ["success", "message"]
+                  "required": [
+                    "success",
+                    "message"
+                  ]
                 }
               }
             }
@@ -488,7 +528,9 @@
       "post": {
         "summary": "Track Prompt",
         "operationId": "trackPrompt",
-        "tags": ["prompt"],
+        "tags": [
+          "prompt"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -531,7 +573,11 @@
                     "optional": true
                   }
                 },
-                "required": ["api_key", "prompt_name", "request_id"]
+                "required": [
+                  "api_key",
+                  "prompt_name",
+                  "request_id"
+                ]
               }
             }
           }
@@ -551,7 +597,10 @@
                       "type": "string"
                     }
                   },
-                  "required": ["success", "message"]
+                  "required": [
+                    "success",
+                    "message"
+                  ]
                 }
               }
             }
@@ -569,7 +618,9 @@
       "post": {
         "summary": "Track Score",
         "operationId": "trackScore",
-        "tags": ["score"],
+        "tags": [
+          "score"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -597,7 +648,11 @@
                     "description": "Your PromptLayer API Key."
                   }
                 },
-                "required": ["request_id", "score", "api_key"]
+                "required": [
+                  "request_id",
+                  "score",
+                  "api_key"
+                ]
               }
             }
           }
@@ -617,7 +672,10 @@
                       "type": "string"
                     }
                   },
-                  "required": ["success", "message"]
+                  "required": [
+                    "success",
+                    "message"
+                  ]
                 }
               }
             }
@@ -635,7 +693,9 @@
       "delete": {
         "summary": "Delete Reports by Name",
         "operationId": "deleteReportsByName",
-        "tags": ["reports"],
+        "tags": [
+          "reports"
+        ],
         "parameters": [
           {
             "name": "report_name",
@@ -671,7 +731,10 @@
                       "type": "string"
                     }
                   },
-                  "required": ["success", "message"]
+                  "required": [
+                    "success",
+                    "message"
+                  ]
                 }
               }
             }
@@ -689,7 +752,9 @@
       "post": {
         "summary": "Create Evaluation Pipeline",
         "operationId": "createEvaluationPipeline",
-        "tags": ["reports"],
+        "tags": [
+          "reports"
+        ],
         "parameters": [
           {
             "name": "X-API-KEY",
@@ -719,7 +784,10 @@
                     "description": "The ID of the dataset on which the report will be based. The dataset must be within an accessible workspace to the user."
                   }
                 },
-                "required": ["name", "test_dataset_id"]
+                "required": [
+                  "name",
+                  "test_dataset_id"
+                ]
               }
             }
           }
@@ -743,7 +811,11 @@
                       "description": "The ID of the created report."
                     }
                   },
-                  "required": ["success", "message", "report_id"]
+                  "required": [
+                    "success",
+                    "message",
+                    "report_id"
+                  ]
                 }
               }
             }
@@ -761,7 +833,9 @@
       "post": {
         "summary": "Run Full Evaluation",
         "operationId": "runReport",
-        "tags": ["reports"],
+        "tags": [
+          "reports"
+        ],
         "parameters": [
           {
             "name": "report_id",
@@ -796,15 +870,23 @@
                     "maxLength": 255
                   },
                   "dataset_id": {
-                    "type": ["integer", "null"],
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "description": "The ID of the dataset to use for the report. If not provided, uses the evaluation pipeline's default dataset."
                   },
                   "refresh_dataset": {
-                    "type": ["boolean", "null"],
+                    "type": [
+                      "boolean",
+                      "null"
+                    ],
                     "description": "Whether to refresh the dataset before running the report. Only applicable for dynamic datasets."
                   }
                 },
-                "required": ["name"]
+                "required": [
+                  "name"
+                ]
               }
             }
           }
@@ -825,7 +907,10 @@
                       "description": "The ID of the created final report."
                     }
                   },
-                  "required": ["success", "report_id"]
+                  "required": [
+                    "success",
+                    "report_id"
+                  ]
                 }
               }
             }
@@ -844,7 +929,10 @@
                       "type": "string"
                     }
                   },
-                  "required": ["success", "message"]
+                  "required": [
+                    "success",
+                    "message"
+                  ]
                 }
               }
             }
@@ -863,7 +951,10 @@
                       "type": "string"
                     }
                   },
-                  "required": ["success", "message"]
+                  "required": [
+                    "success",
+                    "message"
+                  ]
                 }
               }
             }
@@ -882,7 +973,10 @@
                       "type": "string"
                     }
                   },
-                  "required": ["success", "message"]
+                  "required": [
+                    "success",
+                    "message"
+                  ]
                 }
               }
             }
@@ -901,7 +995,10 @@
                       "type": "string"
                     }
                   },
-                  "required": ["success", "message"]
+                  "required": [
+                    "success",
+                    "message"
+                  ]
                 }
               }
             }
@@ -913,7 +1010,9 @@
       "get": {
         "summary": "Get Evaluation",
         "operationId": "getReport",
-        "tags": ["reports"],
+        "tags": [
+          "reports"
+        ],
         "parameters": [
           {
             "name": "report_id",
@@ -959,10 +1058,16 @@
                           "type": "string"
                         },
                         "comment": {
-                          "type": ["string", "null"]
+                          "type": [
+                            "string",
+                            "null"
+                          ]
                         },
                         "is_blueprint": {
-                          "type": ["boolean", "null"]
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
                         },
                         "deleted": {
                           "type": "boolean"
@@ -976,39 +1081,66 @@
                           "format": "date-time"
                         },
                         "score": {
-                          "type": ["object", "null"],
+                          "type": [
+                            "object",
+                            "null"
+                          ],
                           "description": "Report score data"
                         },
                         "score_configuration": {
-                          "type": ["object", "null"],
+                          "type": [
+                            "object",
+                            "null"
+                          ],
                           "description": "Score configuration settings"
                         },
                         "score_matrix": {
-                          "type": ["array", "null"],
+                          "type": [
+                            "array",
+                            "null"
+                          ],
                           "description": "Score matrix for custom scoring"
                         },
                         "score_calculation_error": {
-                          "type": ["string", "null"],
+                          "type": [
+                            "string",
+                            "null"
+                          ],
                           "description": "Error message if score calculation failed"
                         },
                         "parent_report_id": {
-                          "type": ["integer", "null"]
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
                         },
                         "dataset_id": {
-                          "type": ["integer", "null"]
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
                         },
                         "user_id": {
-                          "type": ["integer", "null"]
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
                         },
                         "workspace_id": {
                           "type": "integer"
                         },
                         "prompt_registry_id": {
-                          "type": ["integer", "null"],
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
                           "description": "ID of associated prompt registry"
                         },
                         "prompt_version_number": {
-                          "type": ["integer", "null"],
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
                           "description": "Version number of associated prompt"
                         }
                       },
@@ -1023,7 +1155,10 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": ["RUNNING", "COMPLETED"],
+                      "enum": [
+                        "RUNNING",
+                        "COMPLETED"
+                      ],
                       "description": "Overall status of the report execution"
                     },
                     "stats": {
@@ -1058,7 +1193,9 @@
                           ]
                         }
                       },
-                      "required": ["status_counts"]
+                      "required": [
+                        "status_counts"
+                      ]
                     }
                   },
                   "required": [
@@ -1085,7 +1222,9 @@
       "get": {
         "summary": "Get Evaluation Score",
         "operationId": "getReportScore",
-        "tags": ["reports"],
+        "tags": [
+          "reports"
+        ],
         "parameters": [
           {
             "name": "report_id",
@@ -1124,7 +1263,10 @@
                       "type": "object",
                       "properties": {
                         "overall_score": {
-                          "type": ["number", "null"],
+                          "type": [
+                            "number",
+                            "null"
+                          ],
                           "description": "The overall score of the report"
                         },
                         "score_type": {
@@ -1151,10 +1293,16 @@
                                   "type": "string"
                                 },
                                 "score": {
-                                  "type": ["number", "null"]
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
                                 },
                                 "score_type": {
-                                  "type": ["string", "null"]
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
                                 },
                                 "num_skipped": {
                                   "type": "integer"
@@ -1173,10 +1321,16 @@
                                         "type": "string"
                                       },
                                       "score": {
-                                        "type": ["number", "null"]
+                                        "type": [
+                                          "number",
+                                          "null"
+                                        ]
                                       },
                                       "score_type": {
-                                        "type": ["string", "null"]
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
                                       },
                                       "num_skipped": {
                                         "type": "integer"
@@ -1194,7 +1348,10 @@
                                   "description": "Score matrix from custom scoring logic"
                                 },
                                 "configuration": {
-                                  "type": ["object", "null"],
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
                                   "description": "Custom scoring configuration"
                                 }
                               }
@@ -1218,7 +1375,11 @@
                       ]
                     }
                   },
-                  "required": ["success", "message", "score"]
+                  "required": [
+                    "success",
+                    "message",
+                    "score"
+                  ]
                 }
               }
             }
@@ -1242,7 +1403,9 @@
       "get": {
         "summary": "List Datasets",
         "operationId": "listDatasets",
-        "tags": ["datasets"],
+        "tags": [
+          "datasets"
+        ],
         "parameters": [
           {
             "name": "X-API-KEY",
@@ -1400,7 +1563,9 @@
       "post": {
         "summary": "Create Dataset Group",
         "operationId": "createDatasetGroup",
-        "tags": ["datasets"],
+        "tags": [
+          "datasets"
+        ],
         "parameters": [
           {
             "name": "X-API-KEY",
@@ -1430,7 +1595,10 @@
                     "description": "ID of the workspace where the dataset group will be created"
                   }
                 },
-                "required": ["name", "workspace_id"]
+                "required": [
+                  "name",
+                  "workspace_id"
+                ]
               }
             }
           }
@@ -1456,7 +1624,12 @@
                       "$ref": "#/components/schemas/Dataset"
                     }
                   },
-                  "required": ["success", "message", "dataset_group", "dataset"]
+                  "required": [
+                    "success",
+                    "message",
+                    "dataset_group",
+                    "dataset"
+                  ]
                 }
               }
             }
@@ -1478,7 +1651,9 @@
       "post": {
         "summary": "Create Dataset Version from File",
         "operationId": "createDatasetVersionFromFile",
-        "tags": ["datasets"],
+        "tags": [
+          "datasets"
+        ],
         "parameters": [
           {
             "name": "X-API-KEY",
@@ -1542,7 +1717,11 @@
                       "description": "ID of the created draft dataset"
                     }
                   },
-                  "required": ["success", "message", "dataset_id"]
+                  "required": [
+                    "success",
+                    "message",
+                    "dataset_id"
+                  ]
                 }
               }
             }
@@ -1594,7 +1773,9 @@
       "post": {
         "summary": "Create Dataset Version from Filter Params",
         "operationId": "createDatasetVersionFromFilterParams",
-        "tags": ["datasets"],
+        "tags": [
+          "datasets"
+        ],
         "parameters": [
           {
             "name": "X-API-KEY",
@@ -1681,7 +1862,9 @@
                     "description": "Filter by score ranges"
                   }
                 },
-                "required": ["dataset_group_id"]
+                "required": [
+                  "dataset_group_id"
+                ]
               }
             }
           }
@@ -1749,7 +1932,9 @@
     },
     "/prompt-templates": {
       "get": {
-        "tags": ["prompt-templates"],
+        "tags": [
+          "prompt-templates"
+        ],
         "summary": "Get All",
         "operationId": "get_all_prompt_templates__get",
         "parameters": [
@@ -1795,7 +1980,9 @@
     },
     "/log-request": {
       "post": {
-        "tags": ["request"],
+        "tags": [
+          "request"
+        ],
         "summary": "Log Request",
         "operationId": "logRequest",
         "parameters": [
@@ -1865,7 +2052,9 @@
       "get": {
         "summary": "Get Workflow Version Execution Results",
         "operationId": "getWorkflowVersionExecutionResults",
-        "tags": ["workflow"],
+        "tags": [
+          "workflow"
+        ],
         "parameters": [
           {
             "name": "workflow_version_execution_id",
@@ -1965,7 +2154,9 @@
       "get": {
         "summary": "List Workflows",
         "operationId": "listWorkflows",
-        "tags": ["workflow"],
+        "tags": [
+          "workflow"
+        ],
         "parameters": [
           {
             "name": "X-API-KEY",
@@ -2120,7 +2311,10 @@
                       "example": "Invalid pagination parameters"
                     }
                   },
-                  "required": ["success", "message"]
+                  "required": [
+                    "success",
+                    "message"
+                  ]
                 }
               }
             }
@@ -2141,7 +2335,10 @@
                       "example": "Invalid API key"
                     }
                   },
-                  "required": ["success", "message"]
+                  "required": [
+                    "success",
+                    "message"
+                  ]
                 }
               }
             }
@@ -2153,7 +2350,9 @@
       "post": {
         "summary": "Run Workflow",
         "operationId": "runWorkflow",
-        "tags": ["workflow"],
+        "tags": [
+          "workflow"
+        ],
         "parameters": [
           {
             "name": "workflow_name",
@@ -2230,7 +2429,9 @@
     },
     "/spans-bulk": {
       "post": {
-        "tags": ["spans"],
+        "tags": [
+          "spans"
+        ],
         "summary": "Create Spans Bulk",
         "operationId": "createSpansBulk",
         "parameters": [
@@ -2366,7 +2567,11 @@
             "description": "The ID of the created workflow execution."
           }
         },
-        "required": ["success", "message", "workflow_version_execution_id"],
+        "required": [
+          "success",
+          "message",
+          "workflow_version_execution_id"
+        ],
         "description": "Response after initiating a workflow execution."
       },
       "ErrorResponse": {
@@ -2382,7 +2587,10 @@
             "description": "Error message explaining why the request failed."
           }
         },
-        "required": ["success", "error"],
+        "required": [
+          "success",
+          "error"
+        ],
         "description": "Error response format."
       },
       "Base": {
@@ -2424,7 +2632,9 @@
           }
         },
         "type": "object",
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "title": "Function"
       },
       "FunctionCall": {
@@ -2439,7 +2649,10 @@
           }
         },
         "type": "object",
-        "required": ["name", "arguments"],
+        "required": [
+          "name",
+          "arguments"
+        ],
         "title": "FunctionCall"
       },
       "HTTPValidationError": {
@@ -2481,7 +2694,11 @@
           }
         },
         "type": "object",
-        "required": ["loc", "msg", "type"],
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
         "title": "ValidationError"
       },
       "Model": {
@@ -2502,7 +2719,10 @@
             "type": "object"
           }
         },
-        "required": ["provider", "name"]
+        "required": [
+          "provider",
+          "name"
+        ]
       },
       "Metadata": {
         "title": "Metadata",
@@ -2534,7 +2754,10 @@
                 "type": "object"
               }
             },
-            "required": ["provider", "name"]
+            "required": [
+              "provider",
+              "name"
+            ]
           }
         }
       },
@@ -2578,7 +2801,10 @@
             "anyOf": [
               {
                 "type": "string",
-                "enum": ["openai", "anthropic"]
+                "enum": [
+                  "openai",
+                  "anthropic"
+                ]
               },
               {
                 "type": "null"
@@ -2675,19 +2901,26 @@
           },
           "template_format": {
             "default": "f-string",
-            "enum": ["f-string", "jinja2"],
+            "enum": [
+              "f-string",
+              "jinja2"
+            ],
             "title": "Template Format",
             "type": "string"
           },
           "type": {
             "const": "completion",
             "default": "completion",
-            "enum": ["completion"],
+            "enum": [
+              "completion"
+            ],
             "title": "Type",
             "type": "string"
           }
         },
-        "required": ["content"],
+        "required": [
+          "content"
+        ],
         "title": "Completion Template",
         "type": "object"
       },
@@ -2696,7 +2929,9 @@
           "type": {
             "const": "text",
             "default": "text",
-            "enum": ["text"],
+            "enum": [
+              "text"
+            ],
             "title": "Type",
             "type": "string"
           },
@@ -2705,7 +2940,9 @@
             "type": "string"
           }
         },
-        "required": ["text"],
+        "required": [
+          "text"
+        ],
         "title": "TextContent",
         "type": "object"
       },
@@ -2714,7 +2951,9 @@
           "type": {
             "const": "thinking",
             "default": "thinking",
-            "enum": ["thinking"],
+            "enum": [
+              "thinking"
+            ],
             "title": "Type",
             "type": "string"
           },
@@ -2723,7 +2962,9 @@
             "type": "string"
           }
         },
-        "required": ["thinking"],
+        "required": [
+          "thinking"
+        ],
         "title": "ThinkingContent",
         "type": "object"
       },
@@ -2746,7 +2987,9 @@
           }
         },
         "type": "object",
-        "required": ["url"],
+        "required": [
+          "url"
+        ],
         "title": "ImageURL"
       },
       "Media": {
@@ -2767,7 +3010,9 @@
           }
         },
         "type": "object",
-        "required": ["url"],
+        "required": [
+          "url"
+        ],
         "title": "ImageURL"
       },
       "ImageContent": {
@@ -2775,7 +3020,9 @@
           "type": {
             "const": "image_url",
             "default": "image_url",
-            "enum": ["image_url"],
+            "enum": [
+              "image_url"
+            ],
             "title": "Type",
             "type": "string"
           },
@@ -2795,7 +3042,9 @@
             "title": "Image Variable"
           }
         },
-        "required": ["image_url"],
+        "required": [
+          "image_url"
+        ],
         "title": "ImageContent",
         "type": "object"
       },
@@ -2804,7 +3053,9 @@
           "type": {
             "const": "media",
             "default": "media",
-            "enum": ["media"],
+            "enum": [
+              "media"
+            ],
             "title": "Type",
             "type": "string"
           },
@@ -2812,7 +3063,9 @@
             "$ref": "#/components/schemas/Media"
           }
         },
-        "required": ["media"],
+        "required": [
+          "media"
+        ],
         "title": "MediaContent",
         "type": "object"
       },
@@ -2821,7 +3074,9 @@
           "type": {
             "const": "media_variable",
             "default": "media_variable",
-            "enum": ["media_variable"],
+            "enum": [
+              "media_variable"
+            ],
             "title": "Type",
             "type": "string"
           },
@@ -2831,7 +3086,9 @@
             "description": "Name of the media variable"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "title": "MediaVariable",
         "type": "object"
       },
@@ -2847,7 +3104,10 @@
           },
           "template_format": {
             "type": "string",
-            "enum": ["f-string", "jinja2"],
+            "enum": [
+              "f-string",
+              "jinja2"
+            ],
             "title": "Template Format",
             "default": "f-string"
           },
@@ -2896,7 +3156,9 @@
           }
         },
         "type": "object",
-        "required": ["content"],
+        "required": [
+          "content"
+        ],
         "title": "SystemMessage"
       },
       "UserMessage": {
@@ -2911,7 +3173,10 @@
           },
           "template_format": {
             "type": "string",
-            "enum": ["f-string", "jinja2"],
+            "enum": [
+              "f-string",
+              "jinja2"
+            ],
             "title": "Template Format",
             "default": "f-string"
           },
@@ -2960,7 +3225,9 @@
           }
         },
         "type": "object",
-        "required": ["content"],
+        "required": [
+          "content"
+        ],
         "title": "UserMessage"
       },
       "AssistantMessage": {
@@ -2975,7 +3242,10 @@
           },
           "template_format": {
             "type": "string",
-            "enum": ["f-string", "jinja2"],
+            "enum": [
+              "f-string",
+              "jinja2"
+            ],
             "title": "Template Format",
             "default": "f-string"
           },
@@ -3070,7 +3340,10 @@
           },
           "template_format": {
             "type": "string",
-            "enum": ["f-string", "jinja2"],
+            "enum": [
+              "f-string",
+              "jinja2"
+            ],
             "title": "Template Format",
             "default": "f-string"
           },
@@ -3113,7 +3386,9 @@
           }
         },
         "type": "object",
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "title": "FunctionMessage"
       },
       "DeveloperMessage": {
@@ -3128,7 +3403,10 @@
           },
           "template_format": {
             "type": "string",
-            "enum": ["f-string", "jinja2"],
+            "enum": [
+              "f-string",
+              "jinja2"
+            ],
             "title": "Template Format",
             "default": "f-string"
           },
@@ -3177,7 +3455,9 @@
           }
         },
         "type": "object",
-        "required": ["content"],
+        "required": [
+          "content"
+        ],
         "title": "DeveloperMessage"
       },
       "MessageFunctionCall": {
@@ -3188,7 +3468,9 @@
           }
         },
         "type": "object",
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "title": "MessageFunctionCall"
       },
       "ChatPrompt": {
@@ -3297,7 +3579,9 @@
           "type": {
             "const": "chat",
             "default": "chat",
-            "enum": ["chat"],
+            "enum": [
+              "chat"
+            ],
             "title": "Type",
             "type": "string"
           },
@@ -3310,7 +3594,9 @@
             "type": "array"
           }
         },
-        "required": ["messages"],
+        "required": [
+          "messages"
+        ],
         "title": "Chat Template",
         "type": "object"
       },
@@ -3381,7 +3667,11 @@
           }
         },
         "type": "object",
-        "required": ["id", "prompt_name", "prompt_template"],
+        "required": [
+          "id",
+          "prompt_name",
+          "prompt_template"
+        ],
         "title": "GetPromptTemplateResponse"
       },
       "GetPromptTemplateLabelResponse": {
@@ -3415,7 +3705,9 @@
           }
         },
         "type": "object",
-        "required": ["release_labels"],
+        "required": [
+          "release_labels"
+        ],
         "title": "GetPromptTemplateLabelResponse"
       },
       "BasePromptTemplate": {
@@ -3436,7 +3728,9 @@
           }
         },
         "type": "object",
-        "required": ["prompt_name"],
+        "required": [
+          "prompt_name"
+        ],
         "title": "BasePromptTemplate"
       },
       "PromptVersion": {
@@ -3483,7 +3777,9 @@
           }
         },
         "type": "object",
-        "required": ["prompt_template"],
+        "required": [
+          "prompt_template"
+        ],
         "title": "PromptVersion"
       },
       "CreatePromptTemplate": {
@@ -3495,7 +3791,10 @@
             "$ref": "#/components/schemas/PromptVersion"
           },
           "release_labels": {
-            "type": ["array", "null"],
+            "type": [
+              "array",
+              "null"
+            ],
             "items": {
               "type": "string"
             },
@@ -3503,7 +3802,10 @@
           }
         },
         "type": "object",
-        "required": ["prompt_template", "prompt_version"],
+        "required": [
+          "prompt_template",
+          "prompt_version"
+        ],
         "title": "CreatePromptTemplate"
       },
       "CreatePromptTemplateResponse": {
@@ -3524,7 +3826,10 @@
             "title": "Tags"
           },
           "release_labels": {
-            "type": ["array", "null"],
+            "type": [
+              "array",
+              "null"
+            ],
             "items": {
               "type": "string"
             },
@@ -3571,7 +3876,12 @@
           }
         },
         "type": "object",
-        "required": ["id", "prompt_name", "tags", "prompt_template"],
+        "required": [
+          "id",
+          "prompt_name",
+          "tags",
+          "prompt_template"
+        ],
         "title": "CreatePromptTemplateResponse"
       },
       "ToolCall": {
@@ -3590,7 +3900,10 @@
           }
         },
         "type": "object",
-        "required": ["id", "function"],
+        "required": [
+          "id",
+          "function"
+        ],
         "title": "ToolCall"
       },
       "ToolMessage": {
@@ -3605,7 +3918,10 @@
           },
           "template_format": {
             "type": "string",
-            "enum": ["f-string", "jinja2"],
+            "enum": [
+              "f-string",
+              "jinja2"
+            ],
             "title": "Template Format",
             "default": "f-string"
           },
@@ -3662,7 +3978,10 @@
           }
         },
         "type": "object",
-        "required": ["content", "tool_call_id"],
+        "required": [
+          "content",
+          "tool_call_id"
+        ],
         "title": "ToolMessage"
       },
       "Tool": {
@@ -3677,7 +3996,9 @@
           }
         },
         "type": "object",
-        "required": ["function"],
+        "required": [
+          "function"
+        ],
         "title": "Tool"
       },
       "ChatToolChoice": {
@@ -3692,7 +4013,9 @@
           }
         },
         "type": "object",
-        "required": ["function"],
+        "required": [
+          "function"
+        ],
         "title": "ChatToolChoice"
       },
       "ListPromptTemplates": {
@@ -3758,7 +4081,10 @@
           },
           "template_format": {
             "default": "f-string",
-            "enum": ["f-string", "jinja2"],
+            "enum": [
+              "f-string",
+              "jinja2"
+            ],
             "title": "Template Format",
             "type": "string"
           },
@@ -3799,7 +4125,9 @@
           "role": {
             "const": "placeholder",
             "default": "placeholder",
-            "enum": ["placeholder"],
+            "enum": [
+              "placeholder"
+            ],
             "title": "Role",
             "type": "string"
           },
@@ -3808,7 +4136,9 @@
             "type": "string"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "title": "PlaceholderMessage",
         "type": "object"
       },
@@ -3902,6 +4232,19 @@
             "default": null,
             "title": "Prompt Name"
           },
+          "prompt_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Prompt Id",
+            "description": "The ID of the prompt template used for this request. This is useful for tracking which prompt was used in the request."
+          },
           "prompt_version_number": {
             "anyOf": [
               {
@@ -3972,7 +4315,10 @@
             "$ref": "#/components/schemas/PromptVersion"
           }
         },
-        "required": ["id", "prompt_version"],
+        "required": [
+          "id",
+          "prompt_version"
+        ],
         "title": "LogRequestResponse",
         "type": "object"
       },
@@ -3981,7 +4327,9 @@
           "success": {
             "const": false,
             "default": false,
-            "enum": [false],
+            "enum": [
+              false
+            ],
             "title": "Success",
             "type": "boolean"
           },
@@ -3990,7 +4338,9 @@
             "type": "string"
           }
         },
-        "required": ["message"],
+        "required": [
+          "message"
+        ],
         "title": "BadRequestError",
         "type": "object"
       },
@@ -4025,7 +4375,9 @@
           }
         },
         "type": "object",
-        "required": ["prompt_template"],
+        "required": [
+          "prompt_template"
+        ],
         "title": "PromptBlueprint"
       },
       "SpanKind": {
@@ -4041,7 +4393,11 @@
       },
       "StatusCode": {
         "type": "string",
-        "enum": ["StatusCode.ERROR", "StatusCode.OK", "StatusCode.UNSET"],
+        "enum": [
+          "StatusCode.ERROR",
+          "StatusCode.OK",
+          "StatusCode.UNSET"
+        ],
         "title": "StatusCode"
       },
       "SpanContext": {
@@ -4060,7 +4416,11 @@
             "title": "Trace State"
           }
         },
-        "required": ["trace_id", "span_id", "trace_state"],
+        "required": [
+          "trace_id",
+          "span_id",
+          "trace_state"
+        ],
         "title": "SpanContext"
       },
       "SpanStatus": {
@@ -4075,7 +4435,9 @@
             "nullable": true
           }
         },
-        "required": ["status_code"],
+        "required": [
+          "status_code"
+        ],
         "title": "SpanStatus"
       },
       "SpanResource": {
@@ -4093,7 +4455,10 @@
             "title": "Schema URL"
           }
         },
-        "required": ["attributes", "schema_url"],
+        "required": [
+          "attributes",
+          "schema_url"
+        ],
         "title": "SpanResource"
       },
       "Span": {
@@ -4184,7 +4549,9 @@
             "title": "Spans"
           }
         },
-        "required": ["spans"],
+        "required": [
+          "spans"
+        ],
         "title": "CreateSpansBulk"
       },
       "CreateSpansBulkResponse": {
@@ -4210,7 +4577,10 @@
             "nullable": true
           }
         },
-        "required": ["success", "spans"],
+        "required": [
+          "success",
+          "spans"
+        ],
         "title": "CreateSpansBulkResponse"
       },
       "Dataset": {
@@ -4283,7 +4653,12 @@
             "description": "Whether the dataset group is deleted"
           }
         },
-        "required": ["id", "name", "workspace_id", "is_deleted"],
+        "required": [
+          "id",
+          "name",
+          "workspace_id",
+          "is_deleted"
+        ],
         "title": "DatasetGroup"
       }
     }


### PR DESCRIPTION
Introduce a new `prompt_id` parameter for custom logging to uniquely identify prompt templates.