### PR TITLE
Add model parameter overrides to OpenAPI schema for prompt templates

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2852,6 +2852,20 @@
             ],
             "title": "Modal",
             "description": "Optional model name used for returning default parameters with llm_kwargs."
+          },
+          "model_parameter_overrides": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Model Parameter Overrides",
+            "description": "Optional dictionary of model parameter overrides to use with the prompt template. This will override the parameters at runtime for the specified model and will try to make srue the model supports these parameters. For example, if you supply `maxOutputTokens` for OpenAI, it will be converted to `max_completion_tokens`."
           }
         },
         "type": "object",

--- a/openapi.json
+++ b/openapi.json
@@ -2865,7 +2865,7 @@
             ],
             "default": null,
             "title": "Model Parameter Overrides",
-            "description": "Optional dictionary of model parameter overrides to use with the prompt template. This will override the parameters at runtime for the specified model and will try to make srue the model supports these parameters. For example, if you supply `maxOutputTokens` for OpenAI, it will be converted to `max_completion_tokens`."
+            "description": "Optional dictionary of model parameter overrides to use with the prompt template. This will override the parameters at runtime for the specified model and will try to make sure the model supports these parameters. For example, if you supply `maxOutputTokens` for OpenAI, it will be converted to `max_completion_tokens`."
           }
         },
         "type": "object",


### PR DESCRIPTION
Introduce a new field for model parameter overrides in the OpenAPI schema, allowing users to specify runtime parameters for prompt templates. This enhances flexibility by enabling customization of model behavior.