### PR TITLE
docs: add OpenRouter example to Custom Providers page

### DIFF
--- a/features/custom-providers.mdx
+++ b/features/custom-providers.mdx
@@ -9,7 +9,7 @@ Custom providers let you connect to additional LLM providers beyond the built-in
 
 To add a custom provider to your workspace:
 
-1. Navigate to **Settings → Custom Providers**
+1. Navigate to **Settings → Custom Providers and Models**
 2. Click the **Add Custom Provider** button
 3. Configure the provider with the following details:
 
@@ -24,7 +24,7 @@ To add a custom provider to your workspace:
 
 Once your provider is configured, you can define models for it:
 
-1. Go to **Settings → Custom Models**
+1. In **Settings → Custom Providers and Models**, click on your custom provider row to expand it
 2. Click **Create Custom Model**
 3. Fill in the model configuration:
 
@@ -46,3 +46,40 @@ After setup, your custom models seamlessly integrate with PromptLayer's features
 <img src="/images/custom-provider-use.png" alt="Custom Provider Use" width="650" />
 
 Custom providers give you complete control over your model infrastructure while maintaining all the benefits of PromptLayer's prompt management and observability features.
+
+## Examples
+
+### OpenRouter
+
+[OpenRouter](https://openrouter.ai) provides access to a wide variety of cutting-edge models through a unified API, including models like DeepSeek, Claude, GPT-4, and many others that may not be available through standard providers.
+
+**Configuration Instructions:**
+
+1. **Get an OpenRouter API Key**: Sign up at [OpenRouter](https://openrouter.ai) and obtain your API key from their dashboard.
+
+2. **Add OpenRouter as a Custom Provider** in PromptLayer:
+   - Navigate to **Settings → Custom Providers and Models**
+   - Click **Add Custom Provider**
+   - Configure with these settings:
+     - **Name**: OpenRouter
+     - **Client**: OpenAI (OpenRouter uses OpenAI-compatible endpoints)
+     - **Base URL**: `https://openrouter.ai/api/v1`
+     - **API Key**: Your OpenRouter API key
+
+3. **Save Custom OpenRouter Models** (Recommended):
+   - In **Settings → Custom Providers and Models**, find your OpenRouter provider in the list
+   - Click on the OpenRouter row to expand it
+   - Click **Create Custom Model** in the expanded section
+   - Configure each model:
+     - **Model Name**: Enter the OpenRouter model identifier (e.g., `deepseek/deepseek-chat`, `anthropic/claude-3.5-sonnet`)
+     - **Display Name**: A friendly name like "DeepSeek Chat" or "Claude 3.5 Sonnet"
+     - **Model Type**: Choose "Chat" for most models
+   - Repeat for each model you want to use
+   - The full list of available models can be found in [OpenRouter's documentation](https://openrouter.ai/docs#models)
+
+4. **Use Your Models**:
+   - Your custom models will now appear in the model dropdown in the Playground
+   - Select your models directly from the dropdown - no manual typing needed
+   - All requests will be routed through OpenRouter
+
+OpenRouter automatically handles rate limiting and failover between providers, making it an excellent choice for accessing multiple models through a single integration.


### PR DESCRIPTION
## Summary
- Added an Examples section to the Custom Providers documentation
- OpenRouter is the first example, showing how to access many models through a single integration
- Step-by-step instructions for configuration and model setup

## Changes
- Updated navigation paths to match current UI (Settings → Custom Providers and Models)
- Added detailed OpenRouter configuration instructions
- Explained how to save custom models through the expanded provider view
- Added instructions for using models once configured

## Test plan
- [ ] Review documentation for clarity and accuracy
- [ ] Verify steps match current UI flow
- [ ] Check that OpenRouter configuration works as described