### PR TITLE
Document folders + new eval edit/delete endpoints

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -185,7 +185,11 @@
               "reference/get-report",
               "reference/get-report-score",
               "reference/add-report-columns",
+              "reference/edit-report-column",
+              "reference/delete-report-column",
               "reference/update-report-score-card",
+              "reference/rename-report",
+              "reference/delete-report",
               "reference/delete-reports-by-name"
             ]
           },

--- a/openapi.json
+++ b/openapi.json
@@ -1807,6 +1807,60 @@
             "description": "Report not found or not accessible"
           }
         }
+      },
+      "delete": {
+        "summary": "Delete Evaluation Pipeline",
+        "description": "Archive a single evaluation pipeline by ID. Prefer this over deleteReportsByName when you have the report's ID, since names can collide.",
+        "operationId": "deleteReport",
+        "tags": [
+          "reports"
+        ],
+        "parameters": [
+          {
+            "name": "report_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "ID of the evaluation pipeline to archive."
+          },
+          {
+            "name": "X-API-KEY",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Your PromptLayer API key."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Pipeline archived successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing authentication"
+          },
+          "404": {
+            "description": "Report not found or not accessible"
+          }
+        }
       }
     },
     "/reports/{report_id}/score": {
@@ -1986,6 +2040,266 @@
           },
           "404": {
             "description": "Report not found"
+          }
+        }
+      }
+    },
+    "/reports/{report_id}/rename": {
+      "patch": {
+        "summary": "Rename Evaluation Pipeline",
+        "description": "Rename or retag an evaluation pipeline. Provide name, tags, or both. Use this instead of recreating a misnamed pipeline.",
+        "operationId": "renameReport",
+        "tags": [
+          "reports"
+        ],
+        "parameters": [
+          {
+            "name": "report_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "ID of the evaluation pipeline to rename."
+          },
+          {
+            "name": "X-API-KEY",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Your PromptLayer API key."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 255,
+                    "description": "New name for the evaluation pipeline."
+                  },
+                  "tags": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Replacement tags. Pass an empty array to clear all tags."
+                  }
+                },
+                "description": "At least one of name or tags must be provided."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Pipeline renamed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "report": {
+                      "type": "object",
+                      "description": "The updated report"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error - neither name nor tags was provided"
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing authentication"
+          },
+          "404": {
+            "description": "Report not found or not accessible"
+          }
+        }
+      }
+    },
+    "/report-columns/{report_column_id}": {
+      "patch": {
+        "summary": "Edit Evaluation Pipeline Column",
+        "description": "Update an existing column on an evaluation pipeline. Use this to fix a bug in a CODE_EXECUTION script, change a column's configuration, rename it, or reorder it — without recreating the whole pipeline. Cannot edit DATASET columns. Editing a column re-queues the affected cells.",
+        "operationId": "editReportColumn",
+        "tags": [
+          "reports"
+        ],
+        "parameters": [
+          {
+            "name": "report_column_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "ID of the report column to edit."
+          },
+          {
+            "name": "X-API-KEY",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Your PromptLayer API key."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "report_id": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Parent evaluation pipeline ID. Must match the column's report."
+                  },
+                  "column_type": {
+                    "type": "string",
+                    "description": "Column type. DATASET is not allowed.",
+                    "enum": [
+                      "ABSOLUTE_NUMERIC_DISTANCE",
+                      "AI_DATA_EXTRACTION",
+                      "ASSERT_VALID",
+                      "CONVERSATION_SIMULATOR",
+                      "COALESCE",
+                      "CODE_EXECUTION",
+                      "COMBINE_COLUMNS",
+                      "COMPARE",
+                      "CONTAINS",
+                      "COSINE_SIMILARITY",
+                      "COUNT",
+                      "ENDPOINT",
+                      "MCP",
+                      "HUMAN",
+                      "JSON_PATH",
+                      "LLM_ASSERTION",
+                      "MATH_OPERATOR",
+                      "MIN_MAX",
+                      "PARSE_VALUE",
+                      "APPLY_DIFF",
+                      "PROMPT_TEMPLATE",
+                      "REGEX",
+                      "REGEX_EXTRACTION",
+                      "VARIABLE",
+                      "XML_PATH",
+                      "WORKFLOW",
+                      "CODING_AGENT"
+                    ]
+                  },
+                  "configuration": {
+                    "type": "object",
+                    "description": "Replacement column configuration. Schema varies by column_type.",
+                    "additionalProperties": true
+                  },
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "New column name. Must be unique within the pipeline."
+                  },
+                  "position": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "New 1-based position. Cannot overwrite dataset columns."
+                  }
+                },
+                "required": [
+                  "report_id",
+                  "column_type"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Column updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "report_column": {
+                      "type": "object",
+                      "description": "The updated column"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation failed (invalid type/configuration, duplicate name, etc.)"
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing authentication"
+          },
+          "403": {
+            "description": "Forbidden - Cannot edit DATASET columns or non-blueprint columns"
+          },
+          "404": {
+            "description": "Report column not found or not accessible"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete Evaluation Pipeline Column",
+        "description": "Delete a single column from an evaluation pipeline. Surrounding columns shift left to fill the gap. Cannot delete DATASET columns. Cells in columns to the right of the deleted column are re-queued.",
+        "operationId": "deleteReportColumn",
+        "tags": [
+          "reports"
+        ],
+        "parameters": [
+          {
+            "name": "report_column_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "ID of the report column to delete."
+          },
+          {
+            "name": "X-API-KEY",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Your PromptLayer API key."
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Column deleted successfully"
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing authentication"
+          },
+          "403": {
+            "description": "Forbidden - Cannot delete non-blueprint columns"
+          },
+          "404": {
+            "description": "Report column not found, or column is a DATASET column"
           }
         }
       }
@@ -2999,6 +3313,12 @@
                     "type": "integer",
                     "minimum": 1,
                     "description": "Optional: ID of the workspace where the dataset group will be created. If not provided, uses the workspace associated with your API key."
+                  },
+                  "folder_id": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "nullable": true,
+                    "description": "Optional folder ID to create the dataset group inside. If omitted, the dataset group is created at the workspace root."
                   }
                 },
                 "required": [

--- a/reference/create-dataset-group.mdx
+++ b/reference/create-dataset-group.mdx
@@ -3,8 +3,31 @@ title: "Create Dataset Group"
 openapi: "POST /api/public/v2/dataset-groups"
 ---
 
-Create a new dataset group within a workspace. When a dataset group is created, an initial draft dataset (version_number = -1) is automatically created. Dataset group names must be unique within a workspace.
+Create a new dataset group within a workspace. When a dataset group is created, an initial draft dataset (`version_number = -1`) is automatically created. Dataset group names must be unique within a workspace.
 
 ### Authentication
 
 This endpoint requires API key authentication.
+
+## Request Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `name` | `string` | Yes | Name for the dataset group. Must be unique within the workspace. |
+| `workspace_id` | `integer` | No | Workspace ID. Defaults to the workspace associated with the API key. |
+| `folder_id` | `integer` | No | Folder ID to create the dataset group in. If omitted, the dataset group is created at the workspace root. Use [Resolve Folder ID by Path](/reference/resolve-folder-id) to look up an ID from a path, or [Create Folder](/reference/create-folder) to make one. |
+
+## Example: create a dataset group inside a folder
+
+```python
+import requests
+
+response = requests.post(
+    "https://api.promptlayer.com/api/public/v2/dataset-groups",
+    headers={"X-API-KEY": "your-api-key"},
+    json={
+        "name": "Customer support eval set",
+        "folder_id": 17,
+    },
+)
+```

--- a/reference/delete-report-column.mdx
+++ b/reference/delete-report-column.mdx
@@ -1,0 +1,31 @@
+---
+title: "Delete Evaluation Pipeline Column"
+openapi: "DELETE /report-columns/{report_column_id}"
+---
+
+Delete a single column from an evaluation pipeline. Surrounding columns shift left to fill the gap.
+
+## Important Notes
+
+- **Cannot delete DATASET columns.** The protected columns sourced from the dataset cannot be deleted.
+- **Blueprint pipelines only.** Columns on a finished batch run cannot be deleted; only columns on the blueprint can.
+- **Cells are re-queued.** Any column to the right of the deleted column has its cells re-queued for execution, since references may have shifted.
+
+## Example
+
+```python
+import requests
+
+response = requests.delete(
+    "https://api.promptlayer.com/report-columns/789",
+    headers={"X-API-KEY": "your-api-key"},
+)
+# 204 No Content on success
+```
+
+## Error Responses
+
+| Status | Error |
+|---|---|
+| `403` | Cannot delete a non-blueprint column |
+| `404` | Report column not found, or column is a `DATASET` column |

--- a/reference/delete-report.mdx
+++ b/reference/delete-report.mdx
@@ -1,0 +1,24 @@
+---
+title: "Delete Evaluation Pipeline"
+openapi: "DELETE /reports/{report_id}"
+---
+
+Archive a single evaluation pipeline by ID. Prefer this over [Delete Reports by Name](/reference/delete-reports-by-name) when you have the report's ID, since names can collide across pipelines.
+
+## Example
+
+```python
+import requests
+
+response = requests.delete(
+    "https://api.promptlayer.com/reports/456",
+    headers={"X-API-KEY": "your-api-key"},
+)
+# {"success": true, "message": "Report archived successfully"}
+```
+
+## Error Responses
+
+| Status | Error |
+|---|---|
+| `404` | Report not found or not accessible |

--- a/reference/edit-report-column.mdx
+++ b/reference/edit-report-column.mdx
@@ -1,0 +1,52 @@
+---
+title: "Edit Evaluation Pipeline Column"
+openapi: "PATCH /report-columns/{report_column_id}"
+---
+
+Update an existing column on an evaluation pipeline. Use this to fix a bug in a `CODE_EXECUTION` script, change a column's `configuration`, rename it, or move it to a new position — without recreating the whole pipeline.
+
+## Important Notes
+
+- **Cannot edit DATASET columns.** The protected columns sourced from the dataset cannot be modified.
+- **Blueprint pipelines only.** Columns on a finished batch run cannot be edited; only columns on the blueprint can.
+- **Unique names required.** If you change `name`, the new name must not collide with another column in the same pipeline.
+- **Position changes shift other columns.** Moving a column to a new `position` re-numbers the surrounding columns.
+- **Cells are re-queued.** Editing a column queues all cells in that column (and any column to the right of it) for re-execution.
+
+## Request Body
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `report_id` | `integer` | Yes | Parent evaluation pipeline ID. Must match the column's report. |
+| `column_type` | `string` | Yes | Column type (e.g. `LLM_ASSERTION`, `CODE_EXECUTION`, `PROMPT_TEMPLATE`). `DATASET` is not allowed. See [Node & Column Types](/features/evaluations/column-types). |
+| `configuration` | `object` | No | Replacement column configuration. Schema depends on `column_type`. |
+| `name` | `string` | No | New column name. Must be unique within the pipeline. |
+| `position` | `integer` | No | New 1-based position. Cannot overwrite dataset columns. |
+
+## Example
+
+```python
+import requests
+
+response = requests.patch(
+    "https://api.promptlayer.com/report-columns/789",
+    headers={"X-API-KEY": "your-api-key"},
+    json={
+        "report_id": 456,
+        "column_type": "CODE_EXECUTION",
+        "name": "Strict JSON check",
+        "configuration": {
+            "code": "import json\\ntry:\\n    json.loads(response)\\n    return True\\nexcept Exception:\\n    return False",
+            "language": "PYTHON",
+        },
+    },
+)
+```
+
+## Error Responses
+
+| Status | Error |
+|---|---|
+| `400` | Validation failed (invalid type/configuration, duplicate name, etc.) |
+| `403` | Cannot edit a `DATASET` column or a non-blueprint column |
+| `404` | Report column not found |

--- a/reference/rename-report.mdx
+++ b/reference/rename-report.mdx
@@ -1,0 +1,37 @@
+---
+title: "Rename Evaluation Pipeline"
+openapi: "PATCH /reports/{report_id}/rename"
+---
+
+Rename or retag an evaluation pipeline. Provide `name`, `tags`, or both. Use this instead of recreating a misnamed pipeline.
+
+## Request Body
+
+At least one of `name` or `tags` must be provided.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | `string` | No | New name for the pipeline. 1–255 characters. |
+| `tags` | `string[]` | No | Replacement tags. Pass an empty array to clear all tags. |
+
+## Example
+
+```python
+import requests
+
+response = requests.patch(
+    "https://api.promptlayer.com/reports/456/rename",
+    headers={"X-API-KEY": "your-api-key"},
+    json={
+        "name": "Customer support — production blueprint",
+        "tags": ["production", "support"],
+    },
+)
+```
+
+## Error Responses
+
+| Status | Error |
+|---|---|
+| `400` | Neither `name` nor `tags` was provided |
+| `404` | Report not found or not accessible |

--- a/reference/rest-api-reference.mdx
+++ b/reference/rest-api-reference.mdx
@@ -49,8 +49,16 @@ Here are the calls you can make via our REST API:
 - [Get Report](/reference/get-report)
 - [Get Report Score](/reference/get-report-score)
 - [Add Report Columns](/reference/add-report-columns)
+- [Edit Evaluation Pipeline Column](/reference/edit-report-column)
+- [Delete Evaluation Pipeline Column](/reference/delete-report-column)
 - [Update Report Score Card](/reference/update-report-score-card)
+- [Rename Evaluation Pipeline](/reference/rename-report)
+- [Delete Evaluation Pipeline](/reference/delete-report)
 - [Delete Reports by Name](/reference/delete-reports-by-name)
+
+<Tip>
+Pass `folder_id` on `Create Evaluation Pipeline` (and on the create endpoints under [Prompt Templates](#prompt-templates), [Datasets](#datasets), and [Agents](#agents)) to organize new resources directly into a folder. Use [Resolve Folder ID by Path](/reference/resolve-folder-id) to look up an ID, or [Create Folder](/reference/create-folder) to make one. See [Unified Registry](#unified-registry).
+</Tip>
 
 ### Agents
 

--- a/reference/templates-publish.mdx
+++ b/reference/templates-publish.mdx
@@ -4,3 +4,48 @@ openapi: "POST /rest/prompt-templates"
 ---
 
 Publish Prompt Template allows you to programmatically create a new version of a prompt template and make it available for use in the application.
+
+## Request Body
+
+The request body has two top-level objects: `prompt_template` (template metadata) and `prompt_version` (the version content).
+
+### `prompt_template`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `prompt_name` | `string` | Yes | The unique prompt name within the workspace. 1–512 characters. |
+| `tags` | `string[]` | No | Tags to attach to the prompt registry entry. |
+| `folder_id` | `integer` | No | The ID of the folder to publish the prompt template into. If omitted, the prompt is created at the workspace root. Use [Resolve Folder ID by Path](/reference/resolve-folder-id) to look up an ID from a path, or [Create Folder](/reference/create-folder) to make one. |
+| `workspace_id` | `integer` | No | Optional workspace override; defaults to the workspace associated with the API key. |
+
+### `prompt_version`
+
+The version body (`prompt_template`, `commit_message`, `metadata`, `provider_id`, etc.) is documented in the schema below.
+
+## Example: publish into a folder
+
+```python
+import requests
+
+response = requests.post(
+    "https://api.promptlayer.com/rest/prompt-templates",
+    headers={"X-API-KEY": "your-api-key"},
+    json={
+        "prompt_template": {
+            "prompt_name": "summarizer",
+            "tags": ["production", "summarization"],
+            "folder_id": 42,
+        },
+        "prompt_version": {
+            "prompt_template": {
+                "type": "chat",
+                "messages": [
+                    {"role": "system", "content": [{"type": "text", "text": "You are a summarizer."}]},
+                    {"role": "user", "content": [{"type": "text", "text": "{input}"}]},
+                ],
+            },
+            "commit_message": "Initial release",
+        },
+    },
+)
+```


### PR DESCRIPTION
## Summary

Two customer-reported gaps in the docs:

### 1. Folder support was under-advertised
A customer assumed PromptLayer's REST API didn't support organizing things into folders because:
- `templates-publish.mdx` and `create-dataset-group.mdx` had **no parameter tables at all** — just one-line descriptions, with no hint that `folder_id` was accepted.
- `POST /api/public/v2/dataset-groups` in `openapi.json` was **missing the `folder_id` field**, even though the backend already accepts it (`post_dataset_groups.py:73`). This is a real OpenAPI spec bug.

Coding agents reading the docs would conclude folders weren't supported on those endpoints, so everything they created landed at the workspace root.

### 2. Eval edit/delete endpoints had no docs
The companion backend PR MagnivOrg/promptlayer-app#699 exposes `PATCH /report-columns/{id}`, `DELETE /report-columns/{id}`, and `PATCH /reports/{id}/rename` to API-key auth. `DELETE /reports/{id}` already shipped but was undocumented.

## Changes

### Folder support
- **`reference/templates-publish.mdx`** — expanded from a one-liner to a full parameter table including `prompt_template.folder_id`, with a worked example.
- **`reference/create-dataset-group.mdx`** — same: full parameter table including `folder_id`, with example.
- **`openapi.json`** — added `folder_id` to the `POST /api/public/v2/dataset-groups` request body schema. Real spec bug fix.
- **`reference/rest-api-reference.mdx`** — added a `<Tip>` block pointing readers at `folder_id` and the Unified Registry section.

### New eval endpoint pages
- **`reference/edit-report-column.mdx`** (`PATCH /report-columns/{id}`)
- **`reference/delete-report-column.mdx`** (`DELETE /report-columns/{id}`)
- **`reference/delete-report.mdx`** (`DELETE /reports/{id}`)
- **`reference/rename-report.mdx`** (`PATCH /reports/{id}/rename`)
- **`openapi.json`** — added the four endpoints. \`deleteReport\` is added as a new operation on the existing `/reports/{report_id}` path object.
- **`reference/rest-api-reference.mdx`** — linked the four new pages under Evaluations.
- **`docs.json`** — added the four pages to the Evaluations sidebar group.

## Sequencing
The `edit-report-column`, `delete-report-column`, and `rename-report` docs describe endpoints that require MagnivOrg/promptlayer-app#699 to ship. `delete-report`, the folder docs, and the dataset-groups OpenAPI fix can land independently.

## Test plan
- [x] `python3 -c \"import json; json.load(open('openapi.json'))\"` — valid
- [x] `python3 -c \"import json; json.load(open('docs.json'))\"` — valid
- [ ] Mintlify preview build renders the four new pages and the expanded templates-publish / create-dataset-group pages with their parameter tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)