### PR TITLE
hide the submenu in the topnav on the overview page in mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -200,6 +200,16 @@
   }
 }
 
+@media (max-width: 1023px) {
+  body:has(.promptlayer-landing) #navbar .relative > button.flex.items-center.h-14.py-4.px-5.lg\:hidden.focus\:outline-0.w-full.text-left {
+    display: none;
+  }
+
+  body:has(.promptlayer-landing) #content-container > div.flex.flex-row-reverse.gap-12.box-border.w-full {
+    padding-top: 4rem;
+  }
+}
+
 @media (min-width: 1280px) {
   .promptlayer-feature-grid,
   .promptlayer-info-grid {


### PR DESCRIPTION
hide the submenu in the topnav on the overview page in mobile
<img width="200" height="627" alt="Screenshot 2026-04-14 at 6 38 35 PM" src="https://github.com/user-attachments/assets/a11448e2-1322-412e-86a1-2324fb01a5e5" />

