### PR TITLE
Rebrand Agents back to Workflows

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -32,7 +32,7 @@
         ]
       },
       {
-        "group": "Agents",
+        "group": "Workflows",
         "pages": [
           "agents/mcp"
         ]
@@ -64,7 +64,7 @@
             "icon": "circle-play",
             "pages": [
               "running-requests/promptlayer-run",
-              "running-requests/promptlayer-run-agent",
+              "running-requests/promptlayer-run-workflow",
               "running-requests/traces"
             ]
           },
@@ -133,7 +133,7 @@
               "why-promptlayer/voice-agents"
             ]
           },
-          "why-promptlayer/agents",
+          "why-promptlayer/workflows",
           "why-promptlayer/multi-turn-chat",
           "why-promptlayer/fine-tuning",
           "why-promptlayer/analytics",
@@ -210,7 +210,7 @@
             ]
           },
           {
-            "group": "Agents",
+            "group": "Workflows",
             "pages": [
               "reference/list-workflows",
               "reference/get-workflow",
@@ -294,6 +294,14 @@
     {
       "source": "/languages/javascript",
       "destination": "/sdks/javascript"
+    },
+    {
+      "source": "/why-promptlayer/agents",
+      "destination": "/why-promptlayer/workflows"
+    },
+    {
+      "source": "/running-requests/promptlayer-run-agent",
+      "destination": "/running-requests/promptlayer-run-workflow"
     }
   ]
 }

--- a/features/evaluations/column-types.mdx
+++ b/features/evaluations/column-types.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Node & Column Types"
-description: "Complete reference for all node types used in Agents and evaluation pipelines"
+description: "Complete reference for all node types used in Workflows and evaluation pipelines"
 ---
 
-This page documents all available node types for Agents (workflows) and column types for evaluation pipelines. Agents and evaluations share the same node types—each has specific configuration options that determine its behavior.
+This page documents all available node types for Workflows and column types for evaluation pipelines. Workflows and evaluations share the same node types—each has specific configuration options that determine its behavior.
 
 <Note>
-  In Agents, these are called **nodes**. In evaluation pipelines, they're called
+  In Workflows, these are called **nodes**. In evaluation pipelines, they're called
   **columns**. The configuration is identical.
 </Note>
 

--- a/features/prompt-registry/input-variable-sets.mdx
+++ b/features/prompt-registry/input-variable-sets.mdx
@@ -3,7 +3,7 @@ title: "Input Variable Sets"
 icon: "floppy-disk"
 ---
 
-Input Variable Sets allow you to save and reuse collections of input variables across prompts and agents. Instead of re-entering the same variable values repeatedly, you can create named sets and apply them wherever needed.
+Input Variable Sets allow you to save and reuse collections of input variables across prompts and workflows. Instead of re-entering the same variable values repeatedly, you can create named sets and apply them wherever needed.
 
 ## What are Input Variable Sets?
 
@@ -38,7 +38,7 @@ You can also create Input Variable Sets directly from the Registry:
 
 ## Using Input Variable Sets
 
-Once created, you can load saved variable sets in the prompt editor by clicking the **Load** button in the input variables section. Variable sets also work with agent executions, allowing you to apply consistent inputs for test runs and evaluations.
+Once created, you can load saved variable sets in the prompt editor by clicking the **Load** button in the input variables section. Variable sets also work with workflow executions, allowing you to apply consistent inputs for test runs and evaluations.
 
 <img src="/images/load-input-variable-set.png" alt="Loading a saved input variable set" />
 

--- a/features/prompt-registry/template-variables.mdx
+++ b/features/prompt-registry/template-variables.mdx
@@ -6,7 +6,7 @@ icon: "pen-ruler"
 Creating flexible, dynamic prompts is essential to getting the most out of LLMs. PromptLayer's template system allows you to build reusable prompts where values can be inserted at runtime. This guide explains the two formatting options available in our platform: `f-string` and `jinja2`.
 
 <Info>
-Looking to save and reuse variable values? Check out [Input Variable Sets](/features/prompt-registry/input-variable-sets) to learn how to create named collections of variables that can be applied across prompts, playground, and agents.
+Looking to save and reuse variable values? Check out [Input Variable Sets](/features/prompt-registry/input-variable-sets) to learn how to create named collections of variables that can be applied across prompts, playground, and workflows.
 </Info>
 
 ## What are input variables?

--- a/onboarding-guides/agentic-workflows.mdx
+++ b/onboarding-guides/agentic-workflows.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Agentic Workflows"
+title: "Workflows"
 hidden: true
 noindex: true
 ---
@@ -10,25 +10,25 @@ noindex: true
   create one if needed.
 </Tip>
 
-Agents are sequenced chains of prompts and workflows that can be versioned, monitored, and iterated on from within PromptLayer.
+Workflows are sequenced chains of prompts that can be versioned, monitored, and iterated on from within PromptLayer.
 
 ## Example Use Cases
 
-If you are having trouble creating a reliable prompt, it is often helpful to break the problem down into a few smaller prompts. The chaining and business logic that connects these smaller prompts will be considered an agent.
+If you are having trouble creating a reliable prompt, it is often helpful to break the problem down into a few smaller prompts. The chaining and business logic that connects these smaller prompts will be considered a workflow.
 
 For example, if we are building an AI doctor, it might be helpful to split this into a few individual prompts for appointment scheduling, surgery preparation, and questions about medicine. You might even want to run a prompt on multiple LLM models from OpenAI, Anthropic, and Google, and then use the outputs to create a final answer.
 
-Agents are ideal for:
+Workflows are ideal for:
 
 - **LLM Model Synthesis**: Gathering insights from multiple medical and choosing the best possible answer.
 - **Data Processing Pipelines**: Refining, filtering, or transforming data using multiple models in sequence.
 - **Complex Support Automation**: Automating logical decision-making across different models to allow for unit testing and deterministic results.
 
-## Create an Agent
+## Create a Workflow
 
 ### Start with Multiple Prompts
 
-Gather the prompts required for your agent. Refer to the [Getting Started Guide](/onboarding-guides/getting-started) to learn how to create new prompts.
+Gather the prompts required for your workflow. Refer to the [Getting Started Guide](/onboarding-guides/getting-started) to learn how to create new prompts.
 
 In this example, we will create a an AI doctor that is comprised of 3 prompts.
 
@@ -72,16 +72,16 @@ To find the true answer, use the aggregation of all their answers to pick the be
 {answers}
 ```
 
-### Build the Agent
+### Build the Workflow
 
-Construct an agent to execute your chained prompts one after the other.
+Construct a workflow to execute your chained prompts one after the other.
 
-This agent will take in a user query, rephrase it to something more specific, run the enriched question through the AI doctor prompt multiple times, and then return the best result.
+This workflow will take in a user query, rephrase it to something more specific, run the enriched question through the AI doctor prompt multiple times, and then return the best result.
 
-1. Navigate to **Registry → Agents**.
-2. Click **Create Agent**.
+1. Navigate to **Registry → Workflows**.
+2. Click **Create Workflow**.
 3. Set up input variables. Click on **Input Variables** in the top left, and add `user_question`. Here we can also add a sample value for testing purposes: "Why does my stomach hurt?"
-4. Create the first agent step that will take in the user query and rephrase it to something more detailed.
+4. Create the first workflow step that will take in the user query and rephrase it to something more detailed.
   - Name the step: "Enriched Question".
   - Click **Add Node** and set Node Type to **Prompt Template**.
   - Select the previously created "rephrase-question" prompt.
@@ -90,7 +90,7 @@ This agent will take in a user query, rephrase it to something more specific, ru
    - To change the model, select "ai-doctor" and click the pencil icon next to the model engine.
 6. Combine the three answers. Use node type: "Combine". Connect the 3 parallel AI doctor nodes to this combination step.
 7. Create a final node called "Best Answer" using the prompt "choose-best-answer". Connect it to the combination node created previously.
-8. Mark the "Best Answer" node as an "Output Node" by clicking the three dots on the node. The output node is the final node to run in an agent and will be treated as the "return" statement.
+8. Mark the "Best Answer" node as an "Output Node" by clicking the three dots on the node. The output node is the final node to run in a workflow and will be treated as the "return" statement.
 7. Try clicking "Run" to test it and don't forget to **Save** the configuration!
 
 <iframe
@@ -106,13 +106,13 @@ This agent will take in a user query, rephrase it to something more specific, ru
 
 ---
 
-### Enter Input Variables and Run the Agent
+### Enter Input Variables and Run the Workflow
 
-In the editor view, you can run agent workflows with test input variables.
+In the editor view, you can run workflows with test input variables.
 
-1. Open the agent editor and locate the input variables section **at the top left of the editor panel**.
+1. Open the workflow editor and locate the input variables section **at the top left of the editor panel**.
 2. Enter or update the required input values for each prompt.
-3. Save your changes and **Run** the agent.
+3. Save your changes and **Run** the workflow.
 4. Review the output to ensure the entire workflow functions as expected, and adjust the input values if needed.
 
 <video controls>
@@ -121,18 +121,18 @@ In the editor view, you can run agent workflows with test input variables.
 
 ---
 
-## Agent Tracing
+## Workflow Tracing
 
 Traces are a powerful feature in PromptLayer that allow you to monitor and analyze the execution flow of your applications, including LLM requests.
 
-To see the traces for an agent:
+To see the traces for a workflow:
 
 1. Open the sidebar on the left and select Traces.
-2. Click on the agent name to see the traces for the agent.
+2. Click on the workflow name to see the traces for the workflow.
 
-<img src="./images/traces.gif" alt="Agent Tracing" />
+<img src="./images/traces.gif" alt="Workflow Tracing" />
 
 **Additional Resources:**
 
-- [Learn more about agents](/why-promptlayer/agents).
-- [Add tracing](/running-requests/traces) to your agents.
+- [Learn more about workflows](/why-promptlayer/workflows).
+- [Add tracing](/running-requests/traces) to your workflows.

--- a/onboarding-guides/deployment-strategies.mdx
+++ b/onboarding-guides/deployment-strategies.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Deployment Strategies"
-description: Choose from four integration patterns. Direct SDK calls, webhook caching, GitOps with CI/CD, or managed agents.
+description: Choose from four integration patterns. Direct SDK calls, webhook caching, GitOps with CI/CD, or managed workflows.
 icon: ship
 ---
 
@@ -9,7 +9,7 @@ PromptLayer fits into your stack at four levels of sophistication:
 1. **`promptlayer_client.run`** – zero-setup SDK sugar  
 2. **Webhook-driven caching** – maintain local cache of prompt templates
 3. **GitOps with Webhooks** – keep Git as your source of truth with bi-directional sync
-4. **Managed Agents** – let PromptLayer orchestrate everything server-side  
+4. **Managed Workflows** – let PromptLayer orchestrate everything server-side  
 
 
 <Frame>
@@ -171,13 +171,13 @@ If your CI/CD pipeline runs evaluations as part of the deploy process, you can p
 
 ---
 
-# Run fully-managed Agents
+# Run fully-managed Workflows
 
-For complex workflows requiring orchestration, use PromptLayer's managed agent infrastructure.
+For complex pipelines requiring orchestration, use PromptLayer's managed workflow infrastructure.
 
 ### How it works
-1. Define multi-step workflows in PromptLayer's Agent Builder
-2. Trigger agent execution via API
+1. Define multi-step workflows in PromptLayer's Workflow Builder
+2. Trigger workflow execution via API
 3. Monitor execution on PromptLayer servers
 4. Receive results via webhook or polling
 
@@ -193,7 +193,7 @@ from promptlayer import PromptLayer
 promptlayer_client = PromptLayer(api_key="…")
 
 execution = promptlayer_client.run_workflow(  # SDK method
-    workflow_name="customer_support_agent",   # <- this is an Agent
+    workflow_name="customer_support_workflow",
     workflow_label_name="prod",
     input_variables={"ticket_id": 123}
 )
@@ -204,7 +204,7 @@ import { PromptLayer } from "promptlayer";
 const promptlayer_client = new PromptLayer({ apiKey: "…" });
 
 const execution = await promptlayer_client.runWorkflow({
-  workflowName: "customer_support_agent",    // <- this is an Agent
+  workflowName: "customer_support_workflow",
   workflowLabelName: "prod",
   inputVariables: { ticket_id: 123 }
 });
@@ -214,13 +214,13 @@ const execution = await promptlayer_client.runWorkflow({
 
 Because execution is server-side, you inherit centralized tracing, cost analytics, and secure sandboxed tool-nodes without extra ops.
 
-Learn more: **[Agents documentation ↗](/why-promptlayer/agents)**
+Learn more: **[Workflows documentation ↗](/why-promptlayer/workflows)**
 
 ---
 
 ## Which pattern should I pick?
 
-| Requirement                 | `promptlayer_client.run` | Webhook Cache | GitOps | Managed Agent |
+| Requirement                 | `promptlayer_client.run` | Webhook Cache | GitOps | Managed Workflow |
 | --------------------------- | :----------------------: | :-----------: | :----: | :-----------: |
 | ⏱️ *extreme latency reqs*   |             ❌            |       ✅       |   ➖   |       ✅       |
 | 🛠 *Single LLM call*        |             ✅            |       ✅       |   ✅   |       ➖       |
@@ -236,7 +236,7 @@ Learn more: **[Agents documentation ↗](/why-promptlayer/agents)**
 
 * **Quickstart** – [Your first prompt](/quickstart)
 * **Webhooks** – [Events & signature verification](/features/prompt-registry/webhooks)
-* **Agents** – [Concepts & versioning](/why-promptlayer/agents)
+* **Workflows** – [Concepts & versioning](/why-promptlayer/workflows)
 * **CI for prompts** – [Continuous Integration guide](/features/evaluations/ci)
 
 ---

--- a/overview.mdx
+++ b/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: PromptLayer Documentation
-description: Version, test, and monitor every prompt and agent with evals, tracing, and datasets.
+description: Version, test, and monitor every prompt and workflow with evals, tracing, and datasets.
 mode: custom
 ---
 
@@ -19,7 +19,7 @@ mode: custom
       </div>
       <h1 className="promptlayer-hero-title">PromptLayer</h1>
       <p className="promptlayer-hero-description">
-        Version, test, and monitor every prompt and agent with evals, tracing, and datasets.
+        Version, test, and monitor every prompt and workflow with evals, tracing, and datasets.
       </p>
       <a href="/quickstart" className="promptlayer-quickstart-button">
         Go to Quickstart
@@ -69,7 +69,7 @@ mode: custom
       </a>
 
       <a
-        href="/why-promptlayer/agents"
+        href="/why-promptlayer/workflows"
         className="promptlayer-feature-card promptlayer-card-interactive"
       >
         <div className="promptlayer-feature-badge">
@@ -82,7 +82,7 @@ mode: custom
             className="promptlayer-feature-icon"
           />
         </div>
-        <h3 className="promptlayer-feature-title">Agents</h3>
+        <h3 className="promptlayer-feature-title">Workflows</h3>
         <p className="promptlayer-feature-description">
           Compose multi-step workflows with reusable components, branching, and orchestration.
         </p>
@@ -104,7 +104,7 @@ mode: custom
         </div>
         <h3 className="promptlayer-feature-title">Evaluations</h3>
         <p className="promptlayer-feature-description">
-          Score prompt and agent changes before shipping them.
+          Score prompt and workflow changes before shipping them.
         </p>
       </a>
 
@@ -144,7 +144,7 @@ mode: custom
         </div>
         <h3 className="promptlayer-feature-title">Skills Registry</h3>
         <p className="promptlayer-feature-description">
-          Store and reuse structured skills so agents can consistently apply the right capabilities.
+          Store and reuse structured skills so workflows can consistently apply the right capabilities.
         </p>
       </a>
     </div>
@@ -222,7 +222,7 @@ mode: custom
         </div>
         <h3 className="promptlayer-info-title">Analytics</h3>
         <p className="promptlayer-info-description">
-          Track usage, quality, and outcome trends as prompts and agents evolve over time.
+          Track usage, quality, and outcome trends as prompts and workflows evolve over time.
         </p>
       </a>
 

--- a/quickstart-part-two.mdx
+++ b/quickstart-part-two.mdx
@@ -71,7 +71,7 @@ Run the evaluation to see scores across all test cases. Learn more about [Evalua
   - **Cosine similarity**: Measure semantic similarity between outputs
   - **Code evaluators**: Write custom Python scoring functions
   
-  Agent nodes work the same way in eval pipelines.
+  Workflow nodes work the same way in eval pipelines.
 </Accordion>
 
 ### Testing Different Models
@@ -212,7 +212,7 @@ After running, head to **Logs** in PromptLayer to see your request with the full
   <img src="/new-quickstart-images/request-log.png" alt="Log from SDK run" />
 </Frame>
 
-Use `prompt_release_label="production"` to fetch the version labeled for production. Use `prompt_version=3` to pin to a specific version number. Agents work the same way - just pass the agent name. Store API keys as environment variables (`PROMPTLAYER_API_KEY`, `OPENAI_API_KEY`) - the client reads these automatically.
+Use `prompt_release_label="production"` to fetch the version labeled for production. Use `prompt_version=3` to pin to a specific version number. Workflows work the same way - just pass the workflow name. Store API keys as environment variables (`PROMPTLAYER_API_KEY`, `OPENAI_API_KEY`) - the client reads these automatically.
 
 ### Metadata and Logging
 
@@ -241,7 +241,7 @@ Your metadata and tags appear in the log details, letting you filter and search 
 
 Learn more about [metadata](/features/prompt-history/metadata) and [tagging](/features/prompt-history/tagging-requests).
 
-For agents or complex workflows, enable tracing with `client = PromptLayer(enable_tracing=True)` and use the `@client.traceable` decorator on your functions to see each step as spans. Learn more about [traces](/running-requests/traces).
+For workflows or other complex pipelines, enable tracing with `client = PromptLayer(enable_tracing=True)` and use the `@client.traceable` decorator on your functions to see each step as spans. Learn more about [traces](/running-requests/traces).
 
 ## Organizations
 

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -3,7 +3,7 @@ title: "Quickstart"
 icon: "flag-checkered"
 ---
 
-PromptLayer is your workbench for AI engineering. Version, test, and monitor every prompt and agent with robust evals and tracing. Empower domain experts to iterate alongside engineers in the visual editor.
+PromptLayer is your workbench for AI engineering. Version, test, and monitor every prompt and workflow with robust evals and tracing. Empower domain experts to iterate alongside engineers in the visual editor.
 
 This tutorial walks you through building an AI application that generates cake recipes. By the end, you'll know how to:
 
@@ -187,7 +187,7 @@ All prompts work across models, including [function calling and tool use](/featu
 
 Once your prompt is ready, PromptLayer can manage which version goes live. Release labels let you control which version is in production, so you can update prompts without touching code.
 
-For engineers: PromptLayer offers several [deployment strategies](/onboarding-guides/deployment-strategies) including our Python or TypeScript SDKs, webhook-driven caching, fully managed agents, or [self-hosted](/self-hosted) deployments.
+For engineers: PromptLayer offers several [deployment strategies](/onboarding-guides/deployment-strategies) including our Python or TypeScript SDKs, webhook-driven caching, fully managed workflows, or [self-hosted](/self-hosted) deployments.
 
 ### Release Labels
 
@@ -220,32 +220,32 @@ To start an A/B test, assign release labels to different prompt versions and con
 
 Learn more about [A/B testing](/why-promptlayer/ab-releases).
 
-## Building Agents
+## Building Workflows
 
-Agents are multi-step AI workflows. Unlike a single prompt, an agent can chain multiple prompts together, use tools, and make decisions based on intermediate results.
+Workflows are multi-step AI pipelines. Unlike a single prompt, a workflow can chain multiple prompts together, use tools, and make decisions based on intermediate results.
 
-For example, you could extend the cake recipe generator into an agent that:
+For example, you could extend the cake recipe generator into a workflow that:
 
 1. Generates the recipe (using our prompt from earlier)
 2. Scales the ingredients for 100 people
 3. Calculates the total cost based on current grocery prices
 
-Create an agent by clicking **New** → **Agent**. You can build workflows visually using a drag-and-drop editor. Connect prompts, add conditionals, and loop over data. No code required.
+Create a workflow by clicking **New** → **Workflow**. You can build workflows visually using a drag-and-drop editor. Connect prompts, add conditionals, and loop over data. No code required.
 
 <Frame>
-  <img src="/new-quickstart-images/recipe-agent.png" alt="Creating an agent" />
+  <img src="/new-quickstart-images/recipe-agent.png" alt="Creating a workflow" />
 </Frame>
 
-Like prompts, agents are versioned with commit messages and can be retrieved via the SDK.
+Like prompts, workflows are versioned with commit messages and can be retrieved via the SDK.
 
 <Frame>
   <img
     src="/new-quickstart-images/agent-version-list.png"
-    alt="Agent version history"
+    alt="Workflow version history"
   />
 </Frame>
 
-Learn more about [Agents](/why-promptlayer/agents).
+Learn more about [Workflows](/why-promptlayer/workflows).
 
 ## Evaluations
 
@@ -298,7 +298,7 @@ From the logs table, you can select historical requests and click **Backtest** t
 
 ### Traces and Spans
 
-For agents, [traces](/running-requests/traces) show each step of the workflow as spans. You can see timing, inputs, and outputs for every step. Traces are OpenTelemetry (OTEL) compatible, so you can integrate with your existing observability stack.
+For workflows, [traces](/running-requests/traces) show each step as spans. You can see timing, inputs, and outputs for every step. Traces are OpenTelemetry (OTEL) compatible, so you can integrate with your existing observability stack.
 
 <Frame>
   <img src="/images/new_traces.gif" alt="Trace visualization" />

--- a/reference/create-workflow.mdx
+++ b/reference/create-workflow.mdx
@@ -1,11 +1,9 @@
 ---
-title: "Create Agent"
+title: "Create Workflow"
 openapi: "POST /rest/workflows"
 ---
 
-Create a new Agent or a new version of an existing Agent programmatically. This endpoint allows you to define the complete agent configuration including nodes, edges (conditional connections), input variables, and release labels.
-
-Please note that this feature was previously called "Workflows" and is now called "Agents". Some references to "Workflows" remain in our SDK and will be updated before the feature exits beta.
+Create a new Workflow or a new version of an existing Workflow programmatically. This endpoint allows you to define the complete workflow configuration including nodes, edges (conditional connections), input variables, and release labels.
 
 ## HTTP Request
 
@@ -19,9 +17,9 @@ The request body expects a JSON object with the following structure:
 
 ```json
 {
-  "name": "string (optional, for new agents)",
-  "workflow_id": "integer (optional, for new version of existing agent)",
-  "workflow_name": "string (optional, for new version of existing agent)",
+  "name": "string (optional, for new workflows)",
+  "workflow_id": "integer (optional, for new version of existing workflow)",
+  "workflow_name": "string (optional, for new version of existing workflow)",
   "folder_id": "integer (optional)",
   "commit_message": "string (optional)",
   "nodes": [
@@ -57,12 +55,12 @@ The request body expects a JSON object with the following structure:
 
 ### Parameters
 
-#### Agent Identification
+#### Workflow Identification
 
-- **name** (string, optional): The name for a new agent. If not provided, a name will be auto-generated. Cannot be used with `workflow_id` or `workflow_name`.
-- **workflow_id** (integer, optional): The ID of an existing agent to create a new version for.
-- **workflow_name** (string, optional): The name of an existing agent to create a new version for.
-- **folder_id** (integer, optional): The folder ID to place the agent in.
+- **name** (string, optional): The name for a new workflow. If not provided, a name will be auto-generated. Cannot be used with `workflow_id` or `workflow_name`.
+- **workflow_id** (integer, optional): The ID of an existing workflow to create a new version for.
+- **workflow_name** (string, optional): The name of an existing workflow to create a new version for.
+- **folder_id** (integer, optional): The folder ID to place the workflow in.
 
 #### Version Details
 
@@ -70,9 +68,9 @@ The request body expects a JSON object with the following structure:
 
 #### Nodes
 
-Each node represents a step in the agent workflow:
+Each node represents a step in the workflow:
 
-- **name** (string, required): Unique name for the node within this agent.
+- **name** (string, required): Unique name for the node within this workflow.
 - **node_type** (string, required): The type of node. See [Node Types](#node-types) below.
 - **configuration** (object, required): Node-specific configuration.
 - **dependencies** (array of strings, optional): Names of nodes or input variables this node depends on.
@@ -101,7 +99,7 @@ Edges define conditional branching between nodes:
 
 ## Node Types
 
-Agents use the same node types as evaluation pipelines. For the complete list of supported node types and their detailed configuration options, see the [Node & Column Types](/features/evaluations/column-types) documentation.
+Workflows use the same node types as evaluation pipelines. For the complete list of supported node types and their detailed configuration options, see the [Node & Column Types](/features/evaluations/column-types) documentation.
 
 Common node types include:
 
@@ -148,7 +146,7 @@ Common node types include:
 
 ## Examples
 
-### Create a Simple Agent
+### Create a Simple Workflow
 
 ```python
 import requests
@@ -157,7 +155,7 @@ response = requests.post(
     "https://api.promptlayer.com/rest/workflows",
     headers={"X-API-KEY": "your-api-key"},
     json={
-        "name": "greeting-agent",
+        "name": "greeting-workflow",
         "commit_message": "Initial version",
         "nodes": [
             {
@@ -175,14 +173,14 @@ response = requests.post(
 )
 ```
 
-### Create an Agent with Multiple Nodes
+### Create a Workflow with Multiple Nodes
 
 ```python
 response = requests.post(
     "https://api.promptlayer.com/rest/workflows",
     headers={"X-API-KEY": "your-api-key"},
     json={
-        "name": "classifier-agent",
+        "name": "classifier-workflow",
         "nodes": [
             {
                 "name": "classify",
@@ -226,14 +224,14 @@ response = requests.post(
 )
 ```
 
-### Create an Agent with Conditional Edges
+### Create a Workflow with Conditional Edges
 
 ```python
 response = requests.post(
     "https://api.promptlayer.com/rest/workflows",
     headers={"X-API-KEY": "your-api-key"},
     json={
-        "name": "routing-agent",
+        "name": "routing-workflow",
         "nodes": [
             {
                 "name": "router",
@@ -286,7 +284,7 @@ response = requests.post(
 )
 ```
 
-### Create a New Version of an Existing Agent
+### Create a New Version of an Existing Workflow
 
 ```python
 # By workflow ID
@@ -306,7 +304,7 @@ response = requests.post(
     "https://api.promptlayer.com/rest/workflows",
     headers={"X-API-KEY": "your-api-key"},
     json={
-        "workflow_name": "my-agent",
+        "workflow_name": "my-workflow",
         "commit_message": "v2 updates",
         "nodes": [...],
         "release_labels": ["production"]

--- a/reference/get-workflow-labels.mdx
+++ b/reference/get-workflow-labels.mdx
@@ -1,10 +1,8 @@
 ---
-title: "Get Agent Labels"
+title: "Get Workflow Labels"
 openapi: "GET /workflows/{workflow_id_or_name}/labels"
 ---
 
-List all release labels for an agent (workflow). Returns each label with its name, ID, and the version it points to.
+List all release labels for a workflow. Returns each label with its name, ID, and the version it points to.
 
 This mirrors the [Get Prompt Template Labels](/reference/templates-get-labels) endpoint.
-
-Please note that this feature was previously called "Workflows" and is now called "Agents". Some references to "Workflows" remain in our SDK and will be updated before the feature exits beta.

--- a/reference/get-workflow.mdx
+++ b/reference/get-workflow.mdx
@@ -1,15 +1,13 @@
 ---
-title: "Get Agent"
+title: "Get Workflow"
 openapi: "GET /workflows/{workflow_id_or_name}"
 ---
 
-Retrieve an agent (workflow) by ID or name, including full node configuration, edges, and version details.
+Retrieve a workflow by ID or name, including full node configuration, edges, and version details.
 
 By default, the latest version is returned. Optionally specify `version` (version number) or `label` (release label like "prod") to retrieve a specific version. These parameters are mutually exclusive.
 
-The response includes the complete node definitions with their `configuration` and `dependencies`, making it suitable for inspecting or replicating an agent's setup.
-
-Please note that this feature was previously called "Workflows" and is now called "Agents". Some references to "Workflows" remain in our SDK and will be updated before the feature exits beta.
+The response includes the complete node definitions with their `configuration` and `dependencies`, making it suitable for inspecting or replicating a workflow's setup.
 
 ## Examples
 
@@ -19,7 +17,7 @@ Please note that this feature was previously called "Workflows" and is now calle
 import requests
 
 response = requests.get(
-    "https://api.promptlayer.com/workflows/my-agent",
+    "https://api.promptlayer.com/workflows/my-workflow",
     headers={"X-API-KEY": "your-api-key"},
 )
 ```
@@ -28,7 +26,7 @@ response = requests.get(
 
 ```python
 response = requests.get(
-    "https://api.promptlayer.com/workflows/my-agent",
+    "https://api.promptlayer.com/workflows/my-workflow",
     headers={"X-API-KEY": "your-api-key"},
     params={"version": 3},
 )
@@ -38,7 +36,7 @@ response = requests.get(
 
 ```python
 response = requests.get(
-    "https://api.promptlayer.com/workflows/my-agent",
+    "https://api.promptlayer.com/workflows/my-workflow",
     headers={"X-API-KEY": "your-api-key"},
     params={"label": "prod"},
 )

--- a/reference/introduction.mdx
+++ b/reference/introduction.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Introduction"
-description: "Use the PromptLayer REST API to manage prompts, agents, evaluations, datasets, request logs, traces, and other workspace resources programmatically."
+description: "Use the PromptLayer REST API to manage prompts, workflows, evaluations, datasets, request logs, traces, and other workspace resources programmatically."
 ---
 
 The PromptLayer REST API lets you interact with your workspace directly over HTTP so you can automate updates, run workflows, log activity, and export or organize data from your own systems.
@@ -61,16 +61,16 @@ Generate API keys from the API keys page in your PromptLayer dashboard. Each wor
 - [Delete Reports by Name](/reference/delete-reports-by-name)
 
 <Tip>
-Pass `folder_id` on `Create Evaluation Pipeline` (and on the create endpoints under [Prompt Templates](#prompt-templates), [Datasets](#datasets), and [Agents](#agents)) to organize new resources directly into a folder. Use [Resolve Folder ID by Path](/reference/resolve-folder-id) to look up an ID, or [Create Folder](/reference/create-folder) to make one. See [Unified Registry](#unified-registry).
+Pass `folder_id` on `Create Evaluation Pipeline` (and on the create endpoints under [Prompt Templates](#prompt-templates), [Datasets](#datasets), and [Workflows](#workflows)) to organize new resources directly into a folder. Use [Resolve Folder ID by Path](/reference/resolve-folder-id) to look up an ID, or [Create Folder](/reference/create-folder) to make one. See [Unified Registry](#unified-registry).
 </Tip>
 
-### Agents
+### Workflows
 
-- [List Agents](/reference/list-workflows)
-- [Create Agent](/reference/create-workflow)
-- [Update Agent](/reference/patch-workflow)
-- [Run Agent](/reference/run-workflow)
-- [Get Agent Version Execution Results](/reference/workflow-version-execution-results)
+- [List Workflows](/reference/list-workflows)
+- [Create Workflow](/reference/create-workflow)
+- [Update Workflow](/reference/patch-workflow)
+- [Run Workflow](/reference/run-workflow)
+- [Get Workflow Version Execution Results](/reference/workflow-version-execution-results)
 
 ### Skill Collections
 

--- a/reference/list-workflows.mdx
+++ b/reference/list-workflows.mdx
@@ -1,6 +1,6 @@
 ---
-title: "List Agents"
+title: "List Workflows"
 openapi: "GET /workflows"
 ---
 
-Get a list of all agents in the system.
+Get a list of all workflows in the system.

--- a/reference/patch-workflow.mdx
+++ b/reference/patch-workflow.mdx
@@ -1,16 +1,14 @@
 ---
-title: "Update Agent (PATCH)"
+title: "Update Workflow (PATCH)"
 openapi: "PATCH /rest/workflows/{workflow_id_or_name}"
 ---
 
-Partially update an Agent by creating a new version with merged changes. This endpoint allows you to modify specific nodes without resending the entire configuration.
+Partially update a Workflow by creating a new version with merged changes. This endpoint allows you to modify specific nodes without resending the entire configuration.
 
 The PATCH operation:
 1. Fetches the specified base version (or latest if not specified)
 2. Merges your node updates with existing nodes
 3. Creates a new version with the merged configuration
-
-Please note that this feature was previously called "Workflows" and is now called "Agents". Some references to "Workflows" remain in our SDK and will be updated before the feature exits beta.
 
 ## HTTP Request
 
@@ -18,7 +16,7 @@ Please note that this feature was previously called "Workflows" and is now calle
 
 ## Path Parameters
 
-- **workflow_id_or_name** (string, required): The ID or name of the Agent to update.
+- **workflow_id_or_name** (string, required): The ID or name of the Workflow to update.
 
 ## Request Body
 
@@ -77,7 +75,7 @@ The `nodes` object is keyed by node name:
   "success": true,
   "message": "Workflow version created successfully",
   "workflow_id": 123,
-  "workflow_name": "my-agent",
+  "workflow_name": "my-workflow",
   "workflow_version_id": 789,
   "version_number": 3,
   "base_version": 2,
@@ -106,7 +104,7 @@ Update just the configuration of one node while preserving everything else:
 import requests
 
 response = requests.patch(
-    "https://api.promptlayer.com/rest/workflows/my-agent",
+    "https://api.promptlayer.com/rest/workflows/my-workflow",
     headers={"X-API-KEY": "your-api-key"},
     json={
         "commit_message": "Updated prompt template version",
@@ -126,11 +124,11 @@ response = requests.patch(
 
 ### Add a New Node
 
-Add a new node to an existing agent:
+Add a new node to an existing workflow:
 
 ```python
 response = requests.patch(
-    "https://api.promptlayer.com/rest/workflows/my-agent",
+    "https://api.promptlayer.com/rest/workflows/my-workflow",
     headers={"X-API-KEY": "your-api-key"},
     json={
         "commit_message": "Added logging node",
@@ -151,11 +149,11 @@ response = requests.patch(
 
 ### Remove a Node
 
-Remove a node from the agent:
+Remove a node from the workflow:
 
 ```python
 response = requests.patch(
-    "https://api.promptlayer.com/rest/workflows/my-agent",
+    "https://api.promptlayer.com/rest/workflows/my-workflow",
     headers={"X-API-KEY": "your-api-key"},
     json={
         "commit_message": "Removed deprecated node",
@@ -172,7 +170,7 @@ Create a new version based on an older version (not the latest):
 
 ```python
 response = requests.patch(
-    "https://api.promptlayer.com/rest/workflows/my-agent",
+    "https://api.promptlayer.com/rest/workflows/my-workflow",
     headers={"X-API-KEY": "your-api-key"},
     json={
         "base_version": 5,  # Branch from version 5
@@ -192,7 +190,7 @@ response = requests.patch(
 
 ```python
 response = requests.patch(
-    "https://api.promptlayer.com/rest/workflows/my-agent",
+    "https://api.promptlayer.com/rest/workflows/my-workflow",
     headers={"X-API-KEY": "your-api-key"},
     json={
         "commit_message": "Major update",

--- a/reference/run-workflow.mdx
+++ b/reference/run-workflow.mdx
@@ -1,11 +1,9 @@
 ---
-title: "Run Agent"
+title: "Run Workflow"
 openapi: "POST /workflows/{workflow_name}/run"
 ---
 
-Initiate the execution of a specific Agent by its name. You can specify input variables, metadata, and choose which version of the Agent to run.
-
-Please note that this feature was previously called "Workflows" and is now called "Agents". Some references to "Workflows" remain in our SDK and will be updated before the feature exits beta.
+Initiate the execution of a specific Workflow by its name. You can specify input variables, metadata, and choose which version of the Workflow to run.
 
 ## HTTP Request
 
@@ -13,7 +11,7 @@ Please note that this feature was previously called "Workflows" and is now calle
 
 ## Path Parameters
 
-- **workflow_name** (string, required): The name of the Agent you wish to execute.
+- **workflow_name** (string, required): The name of the Workflow you wish to execute.
 
 ## Request Body
 
@@ -38,18 +36,18 @@ The request body expects a JSON object with the following structure:
 
 ### Parameters
 
-- **workflow_label_name** (string, optional): The label of the specific Agent version to run.
-- **workflow_version_number** (integer, optional): The version number of the Agent to run.
+- **workflow_label_name** (string, optional): The label of the specific Workflow version to run.
+- **workflow_version_number** (integer, optional): The version number of the Workflow to run.
 - **metadata** (object, optional): Additional metadata to attach to the execution.
-- **input_variables** (object, optional): Input variables for the Agent execution.
+- **input_variables** (object, optional): Input variables for the Workflow execution.
 - **return_all_outputs** (boolean, optional, default: false): Whether to return all node outputs or just the final output.
-- **callback_url** (string, optional): An HTTP URL where execution results will be POSTed when the Agent completes. When provided, the API returns HTTP 202 (Accepted) immediately and sends results to this URL asynchronously. Ideal for long-running agents and webhook-based integrations.
+- **callback_url** (string, optional): An HTTP URL where execution results will be POSTed when the Workflow completes. When provided, the API returns HTTP 202 (Accepted) immediately and sends results to this URL asynchronously. Ideal for long-running workflows and webhook-based integrations.
 
 ## Response
 
 **Status Code**: 201 (Created) or 202 (Accepted) if `callback_url` is provided
 
-When a `callback_url` is provided, PromptLayer will POST the following to your callback URL when the agent completes:
+When a `callback_url` is provided, PromptLayer will POST the following to your callback URL when the workflow completes:
 
 ```json
 {

--- a/reference/workflow-version-execution-results.mdx
+++ b/reference/workflow-version-execution-results.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Get Agent Version Execution Results"
+title: "Get Workflow Version Execution Results"
 openapi: "GET /workflow-version-execution-results"
 ---
 
-Retrieve the execution results of a specific Agent version. You can include all output nodes by setting the `return_all_outputs` query parameter to `true`.
+Retrieve the execution results of a specific Workflow version. You can include all output nodes by setting the `return_all_outputs` query parameter to `true`.
 
 | Status | Meaning |
 |--------|---------|
@@ -11,8 +11,6 @@ Retrieve the execution results of a specific Agent version. You can include all 
 | **202** | Execution is **still running**. At least one node is in a non-final status (`QUEUED` or `RUNNING`). |
 
 The response body schema is the same for both status codes. Poll until you receive a `200`.
-
-Please note that this feature was previously called "Workflows" and is now called "Agents". Some references to "Workflows" remain in our SDK and will be updated before the feature exits beta.
 
 <ResponseExample>
 

--- a/running-requests/promptlayer-run-workflow.mdx
+++ b/running-requests/promptlayer-run-workflow.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Run Agent"
+title: "Run Workflow"
 icon: "network-wired"
 ---
 
-The `run_workflow()` method initiates the execution of predefined Agents in PromptLayer, allowing you to start complex, multi-step sequences. For a comprehensive understanding of Agents, including their use cases, key concepts, and versioning, please refer to the [Agents documentation](/why-promptlayer/agents).
+The `run_workflow()` method initiates the execution of predefined Workflows in PromptLayer, allowing you to start complex, multi-step sequences. For a comprehensive understanding of Workflows, including their use cases, key concepts, and versioning, please refer to the [Workflows documentation](/why-promptlayer/workflows).
 
 ## Basic Usage
 
@@ -15,7 +15,7 @@ from promptlayer import PromptLayer
 pl = PromptLayer(api_key="your_api_key")
 
 response = pl.run_workflow(
-    workflow_name="Your Agent Name",
+    workflow_name="Your Workflow Name",
     workflow_version=1
 )
 
@@ -28,7 +28,7 @@ import { PromptLayer } from "promptlayer";
 const pl = new PromptLayer({ apiKey: "your_api_key" });
 
 const response = await pl.runWorkflow({
-  workflowName: "Your Agent Name",
+  workflowName: "Your Workflow Name",
   workflowVersion: 1
 });
 
@@ -39,16 +39,16 @@ console.log(response);
 
 ## Parameters
 
-- `workflow_name` / `workflowName` (str, required): The name of the Agent to run.
-- `input_variables` / `inputVariables` (Dict[str, Any], optional): Variables to be used in the Agent.
-- `metadata` (Dict[str, str], optional): Additional metadata for the Agent run.
-- `workflow_label_name` / `workflowLabelName` (str, optional): Label name for the Agent version.
-- `workflow_version` / `workflowVersion` (int, optional): Specific version number of the Agent to run.
-- `return_all_outputs` / `returnAllOutputs` (bool, optional): Whether to return all outputs from the Agent execution.
+- `workflow_name` / `workflowName` (str, required): The name of the Workflow to run.
+- `input_variables` / `inputVariables` (Dict[str, Any], optional): Variables to be used in the Workflow.
+- `metadata` (Dict[str, str], optional): Additional metadata for the Workflow run.
+- `workflow_label_name` / `workflowLabelName` (str, optional): Label name for the Workflow version.
+- `workflow_version` / `workflowVersion` (int, optional): Specific version number of the Workflow to run.
+- `return_all_outputs` / `returnAllOutputs` (bool, optional): Whether to return all outputs from the Workflow execution.
 
 ## Return Value
 
-By default, when `return_all_outputs` / `returnAllOutputs` is `false`, the method returns only the final node’s output as a single value; when set to `true`, it returns a dictionary (Python) or object (JavaScript) containing detailed outputs (including status) for each node in the agent.
+By default, when `return_all_outputs` / `returnAllOutputs` is `false`, the method returns only the final node’s output as a single value; when set to `true`, it returns a dictionary (Python) or object (JavaScript) containing detailed outputs (including status) for each node in the workflow.
 
 ### When `return_all_outputs` / `returnAllOutputs` is False (default):
 
@@ -97,14 +97,14 @@ Example response:
 
 ```python Python
 response = pl.run_workflow(
-    workflow_name="Data Analysis Agent",
+    workflow_name="Data Analysis Workflow",
     input_variables={"dataset_url": "https://example.com/data.csv"}
 )
 ```
 
 ```js JavaScript
 const response = await pl.runWorkflow({
-  workflowName: "Data Analysis Agent",
+  workflowName: "Data Analysis Workflow",
   inputVariables: { dataset_url: "https://example.com/data.csv" }
 });
 ```
@@ -117,48 +117,48 @@ const response = await pl.runWorkflow({
 
 ```python Python
 response = pl.run_workflow(
-    workflow_name="Customer Service Agent",
+    workflow_name="Customer Service Workflow",
     metadata={"customer_id": "12345"}
 )
 ```
 
 ```js JavaScript
 const response = await pl.runWorkflow({
-  workflowName: "Customer Service Agent",
+  workflowName: "Customer Service Workflow",
   metadata: { customer_id: "12345" }
 });
 ```
 
 </CodeGroup>
 
-### Using Agent Labels
+### Using Workflow Labels
 
 <CodeGroup>
 
 ```python Python
 response = pl.run_workflow(
-    workflow_name="Marketing Campaign Agent",
+    workflow_name="Marketing Campaign Workflow",
     workflow_label_name="production"
 )
 ```
 
 ```js JavaScript
 const response = await pl.runWorkflow({
-  workflowName: "Marketing Campaign Agent",
+  workflowName: "Marketing Campaign Workflow",
   workflowLabelName: "production"
 });
 ```
 
 </CodeGroup>
 
-## Run Agents using the REST API
+## Run Workflows using the REST API
 
-**Step 1: Kick off the agent run**
+**Step 1: Kick off the workflow run**
 
-Start by making a request to ["POST /workflows/agentName/run"](/reference/run-workflow).
+Start by making a request to ["POST /workflows/workflowName/run"](/reference/run-workflow).
 
 This request requires:
-- `input_variables` – JSON object with the variables the agent needs
+- `input_variables` – JSON object with the variables the workflow needs
 - `metadata` – *optional* JSON for extra metadata
 - `return_all_outputs` – Set to `true` if you want to include all intermediate node results
 
@@ -180,15 +180,15 @@ When polling (suggestion):
 
 Depending on if you set `return_all_outputs` or not, you will either return the output value or all node values on completion.
 
-## Run Agents with Callback Webhooks
+## Run Workflows with Callback Webhooks
 
-Instead of polling for results, you can provide a `callback_url` when initiating the agent run. This is ideal for long-running agents and webhook-based integrations.
+Instead of polling for results, you can provide a `callback_url` when initiating the workflow run. This is ideal for long-running workflows and webhook-based integrations.
 
 **How it works:**
 
-1. **Make a single request** to ["POST /workflows/agentName/run"](/reference/run-workflow) with a `callback_url` parameter
+1. **Make a single request** to ["POST /workflows/workflowName/run"](/reference/run-workflow) with a `callback_url` parameter
 2. **Receive immediate response** with HTTP 202 (Accepted) and the `workflow_version_execution_id`
-3. **PromptLayer executes the agent** asynchronously in the background
+3. **PromptLayer executes the workflow** asynchronously in the background
 4. **Results are POSTed** to your callback URL when complete
 
 **Example request:**
@@ -204,7 +204,7 @@ Instead of polling for results, you can provide a `callback_url` when initiating
 
 **Callback payload:**
 
-When the agent completes, PromptLayer will POST the execution results to your callback URL:
+When the workflow completes, PromptLayer will POST the execution results to your callback URL:
 
 ```json
 {
@@ -221,4 +221,4 @@ When the agent completes, PromptLayer will POST the execution results to your ca
 }
 ```
 
-This approach eliminates the need for polling and handles timeouts gracefully, making it perfect for webhook-based integrations. 
+This approach eliminates the need for polling and handles timeouts gracefully, making it perfect for webhook-based integrations.

--- a/sdks/python.mdx
+++ b/sdks/python.mdx
@@ -362,9 +362,9 @@ async def main():
 asyncio.run(main())
 ```
 
-#### Example 2: Async Agent Execution
+#### Example 2: Async Workflow Execution
 
-Run Agents asynchronously for better efficiency:
+Run Workflows asynchronously for better efficiency:
 
 ```python
 import asyncio
@@ -374,7 +374,7 @@ async def main():
     async_promptlayer_client = AsyncPromptLayer(api_key="pl_****")
 
     response = await async_promptlayer_client.run_workflow(
-        workflow_name="example_agent",
+        workflow_name="example_workflow",
         workflow_version=1,
         input_variables={"num1": "1", "num2": "2"},
         return_all_outputs=True,

--- a/self-hosted.mdx
+++ b/self-hosted.mdx
@@ -46,7 +46,7 @@ In-memory data store using Valkey 8.1.0 (Redis-compatible) for:
 - **Redis Queue Background Workers**: Lightweight job processing for real-time operations and quick tasks
 
 #### **Code Executor**
-Isolated Docker container environment for safely executing code blocks in evaluations and the agents builder. Provides sandboxed execution with resource limits and security controls.
+Isolated Docker container environment for safely executing code blocks in evaluations and the workflow builder. Provides sandboxed execution with resource limits and security controls.
 
 ## System Requirements
 

--- a/tutorial-videos.mdx
+++ b/tutorial-videos.mdx
@@ -5,7 +5,7 @@ icon: "video"
 
 These tutorial videos will walk you through key features and help you get up and running quickly.
 
-Let's start with a quick tour of PromptLayer in action: prompt management, testing, deployment, agents, and evaluations all in one workflow.
+Let's start with a quick tour of PromptLayer in action: prompt management, testing, deployment, workflows, and evaluations all in one place.
 
 <iframe 
   src="https://www.loom.com/embed/d06707195f0d433bb970b304c5a4bdc5?hide_owner=true&hide_share=true&hide_title=true&hideEmbedTopBar=true" 
@@ -80,9 +80,9 @@ Learn how to evaluate conversational AI systems using simulated user interaction
   style={{width: "100%", height: "400px"}}
 ></iframe>
 
-## Agents & Workflows
+## Workflows
 
-### Building Multi-Step Agents
+### Building Multi-Step Workflows
 Chain multiple LLM calls together to tackle complex problems.
 
 <iframe 
@@ -120,5 +120,5 @@ For more in-depth information, check out our comprehensive documentation:
 
 - [Prompt Management Guide](https://docs.promptlayer.com/onboarding-guides/prompt-management)
 - [Evaluation Guide](https://docs.promptlayer.com/onboarding-guides/evaluation)
-- [Agentic Workflows Guide](https://docs.promptlayer.com/onboarding-guides/agentic-workflows)
+- [Workflows Guide](https://docs.promptlayer.com/onboarding-guides/agentic-workflows)
 - [Observability Guide](https://docs.promptlayer.com/onboarding-guides/observability)

--- a/why-promptlayer/multi-turn-chat.mdx
+++ b/why-promptlayer/multi-turn-chat.mdx
@@ -3,7 +3,7 @@ title: "Multi-Turn Chat"
 icon: "messages"
 ---
 
-Building reliable conversational AI systems requires careful management of state and conversation history. This guide explains how to implement multi-turn chat using PromptLayer's stateless approach, which enhances reliability and makes your agents easier to test and debug.
+Building reliable conversational AI systems requires careful management of state and conversation history. This guide explains how to implement multi-turn chat using PromptLayer's stateless approach, which enhances reliability and makes your workflows easier to test and debug.
 
 ## Why Stateless Turns?
 
@@ -192,7 +192,7 @@ def run_conversation_with_tools(user_question):
 </Accordion>
 
 <Note>
-You can also implement this pattern using agents for more complex workflows with multiple nodes and conditional logic. See [Running Agents](/running-requests/promptlayer-run-agent) for details on using `promptlayer_client.run_agent()`.
+You can also implement this pattern using workflows for more complex pipelines with multiple nodes and conditional logic. See [Running Workflows](/running-requests/promptlayer-run-workflow) for details on using `promptlayer_client.run_workflow()`.
 </Note>
 
 ## Designing Your Stateless Prompt
@@ -267,7 +267,7 @@ promptlayer_client.run(
 
 ## Handling Tool Calls
 
-For agents that use tools, maintain tool state externally. See our [Tool Calling](/features/prompt-registry/tool-calling) documentation for setting up tool definitions in your prompts:
+For workflows that use tools, maintain tool state externally. See our [Tool Calling](/features/prompt-registry/tool-calling) documentation for setting up tool definitions in your prompts:
 
 ```python
 def handle_tool_execution(agent_response, tool_registry):
@@ -305,6 +305,6 @@ Learn more about setting up comprehensive evaluations in our [Evaluation and Ran
 
 - Explore [Message Placeholders](/features/prompt-registry/placeholder-messages) for dynamic prompt construction
 - Set up [Evaluations](/why-promptlayer/evaluation-and-ranking) for your conversational flows
-- Learn about [Agent development](/why-promptlayer/agents) for complex workflows
+- Learn about [Workflow development](/why-promptlayer/workflows) for complex pipelines
 - Read our guide on [Tool Calling](/features/prompt-registry/tool-calling) for implementing tool-enabled assistants
 - Check out [Structured Outputs](/features/prompt-registry/structured-outputs) for formatted responses

--- a/why-promptlayer/rbac.mdx
+++ b/why-promptlayer/rbac.mdx
@@ -97,7 +97,7 @@ Only organization owners can create custom roles. When creating a custom role, y
 3. Open the **Workspace Roles** tab
 4. Click **+ Create Role** in the top right
 5. Enter a **Role Name** that describes the role's purpose (e.g. "QA Tester")
-6. Select the **permissions** to include, grouped by resource (Prompts, Agents, Datasets, Evaluations, Workspace)
+6. Select the **permissions** to include, grouped by resource (Prompts, Workflows, Datasets, Evaluations, Workspace)
 7. Click **Create Role** to save
 
 ![Create Custom Role](/images/rbac-create-role.png)

--- a/why-promptlayer/workflows.mdx
+++ b/why-promptlayer/workflows.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Agents"
+title: "Workflows"
 icon: "sitemap"
 ---
 
@@ -13,9 +13,9 @@ icon: "sitemap"
   allowfullscreen
 ></iframe>
 
-PromptLayer Agents let you quickly build, launch, and manage AI workflows that use multiple LLMs and business rules. You can create and test these AI systems easily using a visual drag-and-drop tool, and then deploy them without needing to worry about complex infrastructure management.
+PromptLayer Workflows let you quickly build, launch, and manage AI workflows that use multiple LLMs and business rules. You can create and test these AI systems easily using a visual drag-and-drop tool, and then deploy them without needing to worry about complex infrastructure management.
 
-![Agent DAG](/images/agents/workflow-dag.png)
+![Workflow DAG](/images/agents/workflow-dag.png)
 
 ## Use Cases
 
@@ -27,7 +27,7 @@ Improve AI-generated responses by using results from multiple LLM calls, either 
 - Enhanced decision-making by considering multiple perspectives
 - Higher reliability through comparing multiple AI answers
 
-### 2. **Building Complex Agents**
+### 2. **Building Complex Workflows**
 
 Create advanced AI systems that can handle multi-step tasks and solve complex problems. These systems can:
 
@@ -39,13 +39,13 @@ Create advanced AI systems that can handle multi-step tasks and solve complex pr
 
 ### 1. Input Variables
 
-Input Variables are the data you feed into an Agent. They can be text, numbers, or other information the Agent uses in its various steps to produce the final result.
+Input Variables are the data you feed into a Workflow. They can be text, numbers, or other information the Workflow uses in its various steps to produce the final result.
 
 ![Input Variables](/images/agents/input-variables.png)
 
 ### 2. Nodes
 
-Nodes are the building blocks of the Agent. Each node represents a specific action or decision. Types include:
+Nodes are the building blocks of the Workflow. Each node represents a specific action or decision. Types include:
 
 - **Prompt Template**: Make an LLM call using a prompt template from the registry or an [inline template](#inline-templates) defined directly in the node configuration.
 - **Callback Endpoint**: Make external API calls (ex: RAG steps) or trigger callback requests after workflow processes finish.
@@ -56,10 +56,10 @@ Nodes are the building blocks of the Agent. Each node represents a specific acti
 - **Parse Value**: Extract and process specific data types like strings, numbers, or JSON from inputs.
 
 <Info>
-  **Want to learn about all available node types?** Agent nodes use the same
+  **Want to learn about all available node types?** Workflow nodes use the same
   building blocks as evaluation types. [View all eval
   types](/features/evaluations/eval-types) to see the full catalog of nodes you
-  can use in your agents, including LLM assertions, data extraction,
+  can use in your workflows, including LLM assertions, data extraction,
   conversation simulators, and more.
 </Info>
 
@@ -67,7 +67,7 @@ Nodes are the building blocks of the Agent. Each node represents a specific acti
 
 ### 3. Conditional Edges
 
-Conditional Edges allow you to create branching logic within your Agent workflows. By clicking on an edge between nodes, you can define conditions that determine the path your workflow will take. Conditions can be combined using logical operators such as **AND** or **OR**, and support comparisons including:
+Conditional Edges allow you to create branching logic within your Workflows. By clicking on an edge between nodes, you can define conditions that determine the path your workflow will take. Conditions can be combined using logical operators such as **AND** or **OR**, and support comparisons including:
 
 - Equal (`==`)
 - Not Equal (`!=`)
@@ -76,13 +76,13 @@ Conditional Edges allow you to create branching logic within your Agent workflow
 - Less Than or Equal To (`<=`)
 - Greater Than or Equal To (`>=`)
 
-You can compare values against numbers or booleans, and multiple conditions can be combined to create complex branching logic. This enables your Agent to dynamically route execution paths based on intermediate results or external data, allowing for more sophisticated and context-aware workflows.
+You can compare values against numbers or booleans, and multiple conditions can be combined to create complex branching logic. This enables your Workflow to dynamically route execution paths based on intermediate results or external data, allowing for more sophisticated and context-aware workflows.
 
 ![Conditional Edges](/images/agents/conditional-edges.png)
 
 ### 4. Output Nodes
 
-Output Nodes determine what your Agent returns as its final result. When using Conditional Edges to create different paths in your workflow, you can place multiple Output Nodes at the end of different branches. Similar to a "return statement" in programming, whichever Output Node executes successfully first will provide the final output. This allows your Agent to deliver different results based on the specific conditions that were met during the workflow.
+Output Nodes determine what your Workflow returns as its final result. When using Conditional Edges to create different paths in your workflow, you can place multiple Output Nodes at the end of different branches. Similar to a "return statement" in programming, whichever Output Node executes successfully first will provide the final output. This allows your Workflow to deliver different results based on the specific conditions that were met during the workflow.
 
 ![Output Nodes](/images/agents/output-node.png)
 
@@ -90,7 +90,7 @@ Output Nodes determine what your Agent returns as its final result. When using C
 
 Prompt Template nodes can reference a template from the Prompt Registry or define a template inline. Inline templates are useful for quick iteration and experimentation without committing a prompt to the registry.
 
-When creating or updating an agent programmatically, use `inline_template` instead of `template` in a Prompt Template node's configuration:
+When creating or updating a workflow programmatically, use `inline_template` instead of `template` in a Prompt Template node's configuration:
 
 ```json
 {
@@ -135,14 +135,14 @@ You must provide exactly one of `template` (registry reference) or `inline_templ
 
 ## Versioning
 
-Agent versioning automatically tracks changes over time. Each update creates a new version, allowing you to safely experiment with new ideas while keeping the current production version stable. You can view the full history of your Agent's changes, which helps with team collaboration and iterative development.
+Workflow versioning automatically tracks changes over time. Each update creates a new version, allowing you to safely experiment with new ideas while keeping the current production version stable. You can view the full history of your Workflow's changes, which helps with team collaboration and iterative development.
 
 ![Versioning](/images/agents/versions.png)
 
-## Running an Agent
+## Running a Workflow
 
-You can run an Agent in three ways: using the [Python or JavaScript SDK](/running-requests/promptlayer-run-agent), via the [REST API with polling](/running-requests/promptlayer-run-agent#run-agents-using-the-rest-api), or with the [REST API using callback webhooks](/running-requests/promptlayer-run-agent#run-agents-with-callback-webhooks) for long-running agents.
+You can run a Workflow in three ways: using the [Python or JavaScript SDK](/running-requests/promptlayer-run-workflow), via the [REST API with polling](/running-requests/promptlayer-run-workflow#run-workflows-using-the-rest-api), or with the [REST API using callback webhooks](/running-requests/promptlayer-run-workflow#run-workflows-with-callback-webhooks) for long-running workflows.
 
-After running an Agent, the full trace, including spans from all nodes, will be visible in the left traces menu. This allows you to visualize the execution path and see intermediate outputs at each step, helping you debug and optimize your Agent.
+After running a Workflow, the full trace, including spans from all nodes, will be visible in the left traces menu. This allows you to visualize the execution path and see intermediate outputs at each step, helping you debug and optimize your Workflow.
 
 ![Traces](/images/agents/spans.png)


### PR DESCRIPTION
## Summary

Reverts the "Agents" rebrand back to "Workflows" across docs to match the matching [frontend rebrand](https://github.com/MagnivOrg/promptlayer-app) (separate PR).

- Renames `why-promptlayer/agents.mdx` → `workflows.mdx` and `running-requests/promptlayer-run-agent.mdx` → `promptlayer-run-workflow.mdx`; adds redirects from the old paths in `docs.json`
- Flips both "Agents" nav group labels in `docs.json` to "Workflows" (top-level sidebar + REST API Reference)
- Updates titles, prose, and code examples across `reference/*-workflow.mdx`, `overview`, `quickstart`, `quickstart-part-two`, `sdks/python`, `tutorial-videos`, `self-hosted`, `deployment-strategies`, `multi-turn-chat`, `rbac`, `agentic-workflows`, `input-variable-sets`, `template-variables`, `column-types`, and `faq`
- Removes the repeated "this feature was previously called 'Workflows' and is now called 'Agents'" notices in reference docs

## Explicitly left alone (reviewers: please confirm)

- `why-promptlayer/voice-agents.mdx` — separate product (voice AI), not the Workflows feature
- `agents/mcp.mdx` — file path kept to avoid breaking MCP client links; group label was flipped to "Workflows"
- `changelog.mdx` — historical entries
- `openapi.json` — FastAPI-generated spec; will update when backend renames endpoint descriptions
- `features/prompt-registry/webhooks.mdx` `agent_run_finished` event + `agent_name`/`agent_id`/`agent_execution_id` payload fields — stable API contract, rename should happen alongside a backend API rename
- `CODING_AGENT` eval type references in `eval-types.mdx` / `column-types.mdx` — literal node type, not our feature
- Conversation Simulator prose referring to "your AI agent" (the thing being tested)
- External agent SDK docs: `features/integrations.mdx` (Claude Agent SDK, OpenAI Agents SDK) and `features/opentelemetry.mdx` references to those
- Image/video asset paths (`/images/agents/...`, `recipe-agent.png`, `run-agent.mp4`) — unchanged to avoid broken refs
- `onboarding-guides/agentic-workflows.mdx` filename — kept (`hidden: true`); only content updated

## Test plan

- [ ] Preview the docs site and confirm `why-promptlayer/workflows` and `running-requests/promptlayer-run-workflow` render cleanly
- [ ] Confirm redirects from `/why-promptlayer/agents` and `/running-requests/promptlayer-run-agent` work
- [ ] Spot-check nav sidebar labels in all three "Agents" → "Workflows" groups
- [ ] Confirm cross-links (e.g., `overview.mdx` feature card, `deployment-strategies.mdx` "Workflows documentation" link, `multi-turn-chat.mdx` "Running Workflows" link) resolve
- [ ] Verify no visible "Agents" branding remains on pages outside the intentionally-left-alone list

🤖 Generated with [Claude Code](https://claude.com/claude-code)