### PR TITLE
Document dataset-version-from-filter-params with modern API only

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -3532,11 +3532,69 @@
             "application/json": {
               "schema": {
                 "type": "object",
+                "description": "Send either `request_log_ids` (static snapshot) or `filter_group` + `q`/`sort_by`/`sort_order` (dynamic structured query). When both are present, `request_log_ids` wins.",
                 "properties": {
                   "dataset_group_id": {
                     "type": "integer",
                     "minimum": 1,
                     "description": "ID of the dataset group where the new version will be created."
+                  },
+                  "request_log_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "integer",
+                      "minimum": 1
+                    },
+                    "maxItems": 50000,
+                    "description": "Explicit list of request_log ids to include. Capped at 50,000. All ids must belong to the same workspace as the dataset group; cross-workspace ids return 400. Datasets created in this mode are static snapshots — `filter_params` is left null and the dataset cannot be refreshed via run-report."
+                  },
+                  "filter_group": {
+                    "type": "object",
+                    "description": "Structured filter group, identical in shape to the one accepted by `POST /api/public/v2/requests/search`. The full payload is persisted to the dataset so it can be replayed on refresh.",
+                    "properties": {
+                      "logic": {
+                        "type": "string",
+                        "enum": ["AND", "OR"],
+                        "description": "How to combine the filters in this group."
+                      },
+                      "filters": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": ["field", "operator"],
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "description": "Request-log field to filter on (e.g. `request_start_time`, `tags`, `metadata`, `cost`, `latency_ms`)."
+                            },
+                            "operator": {
+                              "type": "string",
+                              "description": "Comparison operator (e.g. `eq`, `in`, `between`, `gte`, `lte`, `contains`)."
+                            },
+                            "value": {
+                              "description": "Operator-specific value. Type depends on the operator (single value, list, or `[from, to]` range)."
+                            },
+                            "nested_key": {
+                              "type": "string",
+                              "description": "For nested fields like `metadata`, the key inside the nested object to filter against."
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "q": {
+                    "type": "string",
+                    "description": "Free-text search query applied alongside `filter_group`. Mirrors `q` from the unified request-log search."
+                  },
+                  "sort_by": {
+                    "type": "string",
+                    "description": "Field to sort the structured query by. Same allowed values as `POST /api/public/v2/requests/search` (e.g. `request_start_time`, `input_tokens`, `output_tokens`, `cost`, `latency_ms`, `status`)."
+                  },
+                  "sort_order": {
+                    "type": "string",
+                    "enum": ["asc", "desc"],
+                    "description": "Sort direction. Defaults to `desc` when `sort_by` is provided."
                   },
                   "variables_to_parse": {
                     "type": "array",
@@ -3544,207 +3602,6 @@
                       "type": "string"
                     },
                     "description": "List of input variables to extract as columns in the resulting dataset."
-                  },
-                  "start_time": {
-                    "type": "string",
-                    "format": "date-time",
-                    "description": "Filter logs after this timestamp (ISO 8601). Example: 2026-04-22T17:00:00Z."
-                  },
-                  "end_time": {
-                    "type": "string",
-                    "format": "date-time",
-                    "description": "Filter logs before this timestamp (ISO 8601). Example: 2026-04-23T17:00:00Z."
-                  },
-                  "limit": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 50000,
-                    "description": "Maximum number of request logs to include. Capped at 50,000."
-                  },
-                  "q": {
-                    "type": "string",
-                    "description": "Free-text search query applied to the prompt input and LLM output."
-                  },
-                  "id": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "description": "Filter to a single request log by its numeric id."
-                  },
-                  "starred": {
-                    "type": "boolean",
-                    "description": "When true, only include starred request logs."
-                  },
-                  "order_by_random": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "When true, sample request logs in random order. Requires `limit` to be set."
-                  },
-                  "metadata_and": {
-                    "type": "array",
-                    "description": "Filter logs whose metadata matches ALL of the provided key/value pairs.",
-                    "items": {
-                      "type": "object",
-                      "required": ["key", "value"],
-                      "properties": {
-                        "key": {
-                          "type": "string",
-                          "maxLength": 1024,
-                          "description": "Metadata key."
-                        },
-                        "value": {
-                          "type": "string",
-                          "description": "Metadata value (values are stored as strings)."
-                        }
-                      }
-                    }
-                  },
-                  "metadata_or": {
-                    "type": "array",
-                    "description": "Filter logs whose metadata matches ANY of the provided key/value pairs.",
-                    "items": {
-                      "type": "object",
-                      "required": ["key", "value"],
-                      "properties": {
-                        "key": {
-                          "type": "string",
-                          "maxLength": 1024
-                        },
-                        "value": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  },
-                  "tags_and": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "Filter logs that have ALL of the provided tags."
-                  },
-                  "tags_or": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "Filter logs that have ANY of the provided tags."
-                  },
-                  "prompt_templates_include": {
-                    "type": "array",
-                    "description": "Include logs associated with any of these prompt templates. Matches by template name, with optional version and/or release label narrowing.",
-                    "items": {
-                      "type": "object",
-                      "required": ["name"],
-                      "properties": {
-                        "name": {
-                          "type": "string",
-                          "description": "Prompt template name."
-                        },
-                        "version_numbers": {
-                          "type": "array",
-                          "items": {
-                            "type": "integer"
-                          },
-                          "description": "Restrict to these specific template version numbers."
-                        },
-                        "labels": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          },
-                          "description": "Restrict to template versions tagged with these release labels (e.g. `prod`, `staging`)."
-                        }
-                      }
-                    }
-                  },
-                  "prompt_templates_exclude": {
-                    "type": "array",
-                    "description": "Exclude logs associated with any of these prompt templates. Same shape as `prompt_templates_include`.",
-                    "items": {
-                      "type": "object",
-                      "required": ["name"],
-                      "properties": {
-                        "name": {
-                          "type": "string"
-                        },
-                        "version_numbers": {
-                          "type": "array",
-                          "items": {
-                            "type": "integer"
-                          }
-                        },
-                        "labels": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "scores": {
-                    "type": "array",
-                    "description": "Filter logs by score comparisons. Each entry asserts that the named score satisfies `operator value`.",
-                    "items": {
-                      "type": "object",
-                      "required": ["name", "operator", "value"],
-                      "properties": {
-                        "name": {
-                          "type": "string",
-                          "maxLength": 512,
-                          "description": "Score name."
-                        },
-                        "operator": {
-                          "type": "string",
-                          "enum": [">", "<", ">=", "<=", "="],
-                          "description": "Comparison operator."
-                        },
-                        "value": {
-                          "type": "integer",
-                          "minimum": 0,
-                          "description": "Score value to compare against."
-                        }
-                      }
-                    }
-                  },
-                  "status": {
-                    "type": "array",
-                    "items": {
-                      "type": "string",
-                      "enum": ["SUCCESS", "WARNING", "ERROR"]
-                    },
-                    "description": "Filter logs by request status."
-                  },
-                  "sort_by": {
-                    "type": "string",
-                    "enum": [
-                      "request_start_time",
-                      "input_tokens",
-                      "output_tokens",
-                      "price",
-                      "score",
-                      "latency",
-                      "prompt_name",
-                      "status"
-                    ],
-                    "description": "Field to sort results by."
-                  },
-                  "sort_order": {
-                    "type": "string",
-                    "enum": ["asc", "desc"],
-                    "description": "Sort direction. Defaults to `desc` when `sort_by` is provided."
-                  },
-                  "include_fields": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "Additional request-log fields to materialize as dataset columns."
-                  },
-                  "transpose_metadata_columns": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "When true, pivot metadata keys into dataset columns. Requires `metadata_and` or `metadata_or` to be set."
                   }
                 },
                 "required": [

--- a/reference/create-dataset-version-from-filter-params.mdx
+++ b/reference/create-dataset-version-from-filter-params.mdx
@@ -3,46 +3,71 @@ title: "Create Dataset Version from Request History"
 openapi: "POST /api/public/v2/dataset-versions/from-filter-params"
 ---
 
-Create a new dataset version by filtering existing request logs. The dataset is populated asynchronously based on the provided filter parameters.
+Create a new dataset version from existing request logs. The dataset is populated asynchronously based on the body you send. There are two input modes:
+
+1. **Explicit ids** — supply `request_log_ids` to add a fixed set of requests by id.
+2. **Structured filter group** — supply `filter_group` (optionally with `q`, `sort_by`, `sort_order`) to populate the dataset from a structured search across your request history.
+
+If both are present, `request_log_ids` wins.
 
 ### Authentication
 
 This endpoint requires API key authentication only.
 
-### Asynchronous Processing
+### Asynchronous processing
 
-This endpoint initiates an asynchronous job to process the request logs based on the filter parameters. The actual dataset version creation happens in the background. A draft dataset (version_number = -1) is created immediately.
+The endpoint always queues a background job to populate the dataset. A draft dataset (`version_number = -1`) is created immediately; the job emails the user and fires the `dataset_version_created_from_filter_params` webhook on completion.
+
+The job is capped at **50,000** request logs per run. `request_log_ids` arrays larger than 50,000 are rejected at validation time.
 
 ### Webhooks
 
 The following webhook is triggered when the process completes:
 
-- `dataset_version_created_from_filter_params` - Sent when the dataset version is successfully created, includes:
+- `dataset_version_created_from_filter_params` — sent when the dataset version is successfully created. Payload:
   - `dataset_id`: ID of the created dataset
   - `rows_added`: Number of rows added to the dataset
   - `dataset_version_number`: Final version number assigned
 
-### Notes
+### Modes
 
-- If an existing draft dataset exists for the dataset group, it will be updated with new filter params
-- If no matching request logs are found, an empty dataset version is created
-- Failed drafts are automatically cleaned up
-
-### Filtering by metadata
-
-Metadata filters are provided as a list of `{key, value}` pairs under either `metadata_and` (all must match) or `metadata_or` (any must match). Values are compared as strings.
+#### Explicit ids
 
 ```json
 {
-  "dataset_group_id": 20123,
-  "prompt_templates_include": [{ "name": "generate-summary" }],
-  "metadata_and": [
-    { "key": "app_name", "value": "local" }
-  ],
-  "start_time": "2026-04-22T17:00:00Z",
-  "end_time": "2026-04-23T17:00:00Z",
-  "limit": 25
+  "dataset_group_id": 123,
+  "request_log_ids": [1001, 1002, 1003]
 }
 ```
 
-Unknown fields in the request body are ignored silently, so a typo such as `"metadata": { "app_name": "local" }` will not produce an error — it simply will not filter. Use `metadata_and` / `metadata_or` exactly as shown above.
+All ids must belong to the same workspace as the dataset group; otherwise the call returns `400`. Datasets created in this mode are **static snapshots** — `filter_params` is left null on the dataset, and they cannot be refreshed via the run-report `refresh_dataset` flow.
+
+#### Structured filter group
+
+The `filter_group` payload uses the same shape as [`POST /api/public/v2/requests/search`](/reference/search-request-logs), so anything you can express in the request-log search you can use here.
+
+```json
+{
+  "dataset_group_id": 123,
+  "filter_group": {
+    "logic": "AND",
+    "filters": [
+      { "field": "request_start_time", "operator": "between", "value": ["2026-04-01T00:00:00Z", "2026-04-30T23:59:59Z"] },
+      { "field": "tags", "operator": "in", "value": ["staging"] },
+      { "field": "metadata", "operator": "eq", "nested_key": "app_name", "value": "checkout" }
+    ]
+  },
+  "q": "timeout",
+  "sort_by": "request_start_time",
+  "sort_order": "desc"
+}
+```
+
+The full `filter_group` payload is persisted to the dataset, so the run-report `refresh_dataset` flow can replay the same query later.
+
+### Notes
+
+- If a draft dataset already exists for the dataset group, it is reused; the new payload overwrites its `filter_params`.
+- If no matching request logs are found, an empty dataset version is created.
+- Failed drafts are automatically cleaned up.
+- Only fields documented above are accepted in the request body. Sending an unknown field returns a 400 validation error.


### PR DESCRIPTION
## Summary
- Replace the legacy filter-params surface (`start_time`/`end_time`/`tags_and`/`tags_or`/`metadata_and`/`metadata_or`/`prompt_templates_include`/`prompt_templates_exclude`/`scores`/`sort_by` enum/`status`/`order_by_random`/`transpose_metadata_columns`/`include_fields`/`id`/`starred`/`limit`) with the two modes the endpoint actually advertises:
  - **Explicit ids** — `request_log_ids` for static snapshots.
  - **Structured filter group** — `filter_group` + `q`/`sort_by`/`sort_order`, matching the shape of `POST /api/public/v2/requests/search`.
- The endpoint stays **backwards compatible** in the backend; existing customers' legacy payloads keep working. We just stop surfacing those fields in the public reference so new integrations are guided to the unified search shape.
- Note that unknown fields now return a 400 (the body schema rejects extras after the recent inheritance refactor).

## Why
- The legacy filter shape predates the unified `RequestLogQuery` payload used by `/api/public/v2/requests/search` and the structured search backend.
- New customers steered to legacy fields end up with a payload that no longer evolves alongside the rest of the request-log API.
- Surfacing two well-defined modes — by-id and by-filter-group — keeps the docs consistent with the broader v2 contract.

## Test plan
- [x] Validated `openapi.json` parses as JSON.
- [ ] Mintlify preview to confirm the rendered reference page and Try-It-Out panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)