### PR TITLE
Add PROVIDER_PARTIAL_RESPONSE warning

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -11604,6 +11604,7 @@
                   "PROVIDER_TIMEOUT",
                   "PROVIDER_QUOTA_LIMIT",
                   "PROVIDER_RATE_LIMIT",
+                  "PROVIDER_PARTIAL_RESPONSE",
                   "PROVIDER_AUTH_ERROR",
                   "PROVIDER_ERROR",
                   "TEMPLATE_RENDER_ERROR",
@@ -11617,7 +11618,7 @@
             ],
             "default": null,
             "title": "Error Type",
-            "description": "Categorized error type.\n\n| Value | Description | Allowed Statuses |\n|-------|-------------|------------------|\n| `PROVIDER_RATE_LIMIT` | Rate limit hit on provider API | WARNING, ERROR |\n| `PROVIDER_QUOTA_LIMIT` | Account quota or spending limit exceeded | WARNING, ERROR |\n| `VARIABLE_MISSING_OR_EMPTY` | Required template variable was missing or empty | WARNING |\n| `PROVIDER_TIMEOUT` | Request timed out | ERROR |\n| `PROVIDER_AUTH_ERROR` | Authentication failed with provider | ERROR |\n| `PROVIDER_ERROR` | General provider-side error | ERROR |\n| `TEMPLATE_RENDER_ERROR` | Failed to render prompt template | ERROR |\n| `UNKNOWN_ERROR` | Uncategorized error | WARNING, ERROR |"
+            "description": "Categorized error type.\n\n| Value | Description | Allowed Statuses |\n|-------|-------------|------------------|\n| `PROVIDER_RATE_LIMIT` | Rate limit hit on provider API | WARNING, ERROR |\n| `PROVIDER_QUOTA_LIMIT` | Account quota or spending limit exceeded | WARNING, ERROR |\n| `PROVIDER_PARTIAL_RESPONSE` | Provider returned a successful response, but the saved output may be incomplete, filtered, blocked, malformed, or otherwise partial | WARNING |\n| `VARIABLE_MISSING_OR_EMPTY` | Required template variable was missing or empty | WARNING |\n| `PROVIDER_TIMEOUT` | Request timed out | ERROR |\n| `PROVIDER_AUTH_ERROR` | Authentication failed with provider | ERROR |\n| `PROVIDER_ERROR` | General provider-side error | ERROR |\n| `TEMPLATE_RENDER_ERROR` | Failed to render prompt template | ERROR |\n| `UNKNOWN_ERROR` | Uncategorized error | WARNING, ERROR |"
           },
           "error_message": {
             "anyOf": [

--- a/reference/log-request.mdx
+++ b/reference/log-request.mdx
@@ -137,6 +137,10 @@ For complete examples with thinking content blocks and full code samples, see:
 
 You can log failed or problematic requests using the `status`, `error_type`, and `error_message` fields. This is useful for monitoring error rates, debugging issues, and tracking provider reliability.
 
+### Supported Error Types
+
+Use `error_type` to categorize warnings and errors consistently across dashboards, API responses, and filters. A full list of supported values is available in the `error_type` field below.
+
 ### Example: Logging a Failed Request
 
 ```json


### PR DESCRIPTION
LLM providers return with HTTP 2xx for partial, filtered, blocked, malformed responses. Capture it and propagate