### PR TITLE
cover public entity listing endpoints

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -303,7 +303,10 @@
             "pages": [
               "reference/create-folder",
               "reference/update-folder",
+              "reference/list-folders",
               "reference/list-folder-entities",
+              "reference/list-ab-tests",
+              "reference/list-input-variable-sets",
               "reference/move-folder-entities",
               "reference/delete-folder-entities",
               "reference/resolve-folder-id",

--- a/reference/external-ids-overview.mdx
+++ b/reference/external-ids-overview.mdx
@@ -16,7 +16,7 @@ description: "Attach identifiers from your own systems to PromptLayer resources 
 |---|---|
 | Set when creating an entity | [`POST /rest/prompt-templates`](/reference/templates-publish#body-external-ids) include `external_ids` in the payload body. |
 | Set on an existing resource | [`POST /prompt-templates/{prompt_template_id}/external-ids`](/reference/external-ids-prompt-templates-attach) |
-| Get an entity by external ID | [`GET /prompt-templates?external_source=...&external_id=...`](/reference/list-prompt-templates#query-external-source) (prompt templates only) |
+| Get an entity by external ID | [`GET /prompt-templates?external_source=...&external_id=...`](/reference/list-prompt-templates), [`GET /api/public/v2/folders?external_source=...&external_id=...`](/reference/list-folders), [`GET /api/public/v2/ab-tests?external_source=...&external_id=...`](/reference/list-ab-tests), [`GET /api/public/v2/input-variable-sets?external_source=...&external_id=...`](/reference/list-input-variable-sets), or [`GET /api/public/v2/folders/entities?external_source=...&external_id=...`](/reference/list-folder-entities) |
 | Get external IDs for an entity | [`GET /prompt-templates/{prompt_template_id}/external-ids`](/reference/external-ids-prompt-templates-list) |
 | Delete an external ID from an entity | [`DELETE /prompt-templates/{prompt_template_id}/external-ids/{source}/{external_id}`](/reference/external-ids-prompt-templates-delete) |
 

--- a/reference/list-ab-tests.mdx
+++ b/reference/list-ab-tests.mdx
@@ -1,0 +1,54 @@
+---
+title: "List AB Tests"
+---
+
+Get a paginated list of AB tests in a workspace.
+
+Use this endpoint when you want AB tests only, rather than the mixed-entity response returned by [List Folder Entities](/reference/list-folder-entities).
+
+## Endpoint
+
+`GET /api/public/v2/ab-tests`
+
+## Authentication
+
+This endpoint requires API key authentication via the `X-API-KEY` header.
+
+## Query Parameters
+
+### Required
+
+- `workspace_id`: Workspace to query when your API key can access more than one workspace.
+
+### Filtering
+
+- `name`: Case-insensitive partial match on the AB test name.
+- `created_by_email`: Return only AB tests created by the matching user email.
+- `created_after` / `created_before`: Filter by creation timestamp.
+- `updated_after` / `updated_before`: Filter by last update timestamp.
+- `external_source` and `external_id`: Resolve a specific AB test by its external ID mapping. These parameters must be provided together.
+
+### Sorting
+
+- `sort_by`: One of `created_at`, `updated_at`, `name`, or `id`.
+- `sort_order`: `asc` or `desc`. Defaults to `desc`.
+
+## Response
+
+Returns:
+
+- `success`: Boolean success flag.
+- `ab_tests`: Array of AB test objects.
+
+Each AB test includes its attached `external_ids` array.
+
+## Notes
+
+- `created_by_email` only matches AB tests created after creator tracking was added. Older AB tests without a recorded creator are excluded from that filter.
+
+## Example
+
+```bash
+curl -X GET "https://api.promptlayer.com/api/public/v2/ab-tests?workspace_id=123&external_source=acme&external_id=ab_test_42" \
+  -H "X-API-KEY: your_api_key"
+```

--- a/reference/list-ab-tests.mdx
+++ b/reference/list-ab-tests.mdx
@@ -1,5 +1,6 @@
 ---
 title: "List AB Tests"
+openapi: "GET /api/public/v2/ab-tests"
 ---
 
 Get a paginated list of AB tests in a workspace.

--- a/reference/list-folder-entities.mdx
+++ b/reference/list-folder-entities.mdx
@@ -3,7 +3,7 @@ title: "List Folder Entities"
 openapi: "GET /api/public/v2/folders/entities"
 ---
 
-Lists entities within a folder or at the workspace root. Returns folders, prompts, snippets, workflows, datasets, evaluations, AB tests, and input variable sets.
+Lists entities within a folder or at the workspace root. Returns folders, prompts, snippets, workflows, datasets, evaluations, AB tests, input variable sets, skill collections, and tools.
 
 This endpoint is the primary way to browse the unified registry programmatically — equivalent to viewing the registry page in the PromptLayer dashboard.
 
@@ -32,7 +32,43 @@ This endpoint is the primary way to browse the unified registry programmatically
 </ParamField>
 
 <ParamField query="tags" type="string[]">
-  Filter entities by tags. Only entities that contain all specified tags are returned. Applies to prompts, workflows, datasets, and evaluations. Folders, AB tests, and input variable sets are excluded when this filter is active.
+  Filter entities by tags. Only entities that contain all specified tags are returned. Applies to prompts, workflows, datasets, and evaluations. Folders, AB tests, input variable sets, skill collections, and tools are excluded when this filter is active.
+</ParamField>
+
+<ParamField query="created_by_email" type="string">
+  Filter entities by creator email. This applies across all supported entity types, but older folders, AB tests, and input variable sets created before creator tracking was added do not have a recorded creator and are excluded from this filter.
+</ParamField>
+
+<ParamField query="created_after" type="datetime">
+  Return only entities created at or after this timestamp.
+</ParamField>
+
+<ParamField query="created_before" type="datetime">
+  Return only entities created at or before this timestamp.
+</ParamField>
+
+<ParamField query="updated_after" type="datetime">
+  Return only entities updated at or after this timestamp.
+</ParamField>
+
+<ParamField query="updated_before" type="datetime">
+  Return only entities updated at or before this timestamp.
+</ParamField>
+
+<ParamField query="external_source" type="string">
+  Resolve a single entity by external ID. Must be provided together with `external_id`.
+</ParamField>
+
+<ParamField query="external_id" type="string">
+  Resolve a single entity by external ID. Must be provided together with `external_source`.
+</ParamField>
+
+<ParamField query="sort_by" type="string">
+  Sort results by `created_at`, `updated_at`, `name`, or `id`.
+</ParamField>
+
+<ParamField query="sort_order" type="string" default="desc">
+  Sort direction for `sort_by`. Use `asc` or `desc`.
 </ParamField>
 
 ### Search
@@ -61,7 +97,7 @@ Returns an object with a single `entities` array. Each entity has the following 
   <Expandable title="Entity object">
     <ResponseField name="id" type="integer">Unique entity identifier.</ResponseField>
     <ResponseField name="name" type="string">Display name of the entity.</ResponseField>
-    <ResponseField name="type" type="string">One of: `FOLDER`, `PROMPT`, `SNIPPET`, `WORKFLOW`, `DATASET`, `REPORT`, `AB_TEST`, `INPUT_VARIABLE_SET`.</ResponseField>
+    <ResponseField name="type" type="string">One of: `FOLDER`, `PROMPT`, `SNIPPET`, `WORKFLOW`, `DATASET`, `REPORT`, `AB_TEST`, `INPUT_VARIABLE_SET`, `SKILL_COLLECTION`, `TOOL`.</ResponseField>
     <ResponseField name="created_at" type="string | null">ISO 8601 creation timestamp.</ResponseField>
     <ResponseField name="updated_at" type="string | null">ISO 8601 last-updated timestamp.</ResponseField>
     <ResponseField name="folder_id" type="integer | null">ID of the parent folder, or `null` if at the workspace root.</ResponseField>
@@ -81,13 +117,15 @@ When `include_metadata=true`, the `metadata` field contains type-specific inform
 | **PROMPT** / **SNIPPET** | `type` (`"chat"` or `"completion"` or `null`), `latest_version_number` |
 | **WORKFLOW** | `latest_version_number` |
 | **DATASET** | `isDraft` (boolean — `true` if only draft versions exist), `latest_version_number` |
-| **FOLDER**, **REPORT**, **AB_TEST**, **INPUT_VARIABLE_SET** | Empty object `{}` |
+| **FOLDER**, **REPORT**, **AB_TEST**, **INPUT_VARIABLE_SET**, **SKILL_COLLECTION** | Empty object `{}` |
+| **TOOL** | `prompt_count`, `latest_version_number` |
 
 ## Sorting Behavior
 
 - **Semantic search**: Results are sorted by relevance (distance ascending).
 - **Text search**: Prompts and snippets with a name match are prioritized above content-only matches.
-- **No search**: Results are returned in default database order.
+- **Explicit sort**: Use `sort_by` with `sort_order`.
+- **No search or sort**: Results are returned in default database order.
 
 ## Examples
 
@@ -130,6 +168,13 @@ curl -X GET "https://api.promptlayer.com/api/public/v2/folders/entities?search_q
 
 ```bash
 curl -X GET "https://api.promptlayer.com/api/public/v2/folders/entities?tags=production&tags=v2&flatten=true" \
+  -H "X-API-KEY: your_api_key"
+```
+
+### Resolve an entity by external ID
+
+```bash
+curl -X GET "https://api.promptlayer.com/api/public/v2/folders/entities?external_source=acme&external_id=tool_123" \
   -H "X-API-KEY: your_api_key"
 ```
 

--- a/reference/list-folders.mdx
+++ b/reference/list-folders.mdx
@@ -1,0 +1,54 @@
+---
+title: "List Folders"
+---
+
+Get a paginated list of folders in a workspace.
+
+Use this endpoint when you want folders only, rather than the mixed-entity response returned by [List Folder Entities](/reference/list-folder-entities).
+
+## Endpoint
+
+`GET /api/public/v2/folders`
+
+## Authentication
+
+This endpoint requires API key authentication via the `X-API-KEY` header.
+
+## Query Parameters
+
+### Required
+
+- `workspace_id`: Workspace to query when your API key can access more than one workspace.
+
+### Filtering
+
+- `name`: Case-insensitive partial match on the folder name.
+- `created_by_email`: Return only folders created by the matching user email.
+- `created_after` / `created_before`: Filter by creation timestamp.
+- `updated_after` / `updated_before`: Filter by last update timestamp.
+- `external_source` and `external_id`: Resolve a specific folder by its external ID mapping. These parameters must be provided together.
+
+### Sorting
+
+- `sort_by`: One of `created_at`, `updated_at`, `name`, or `id`.
+- `sort_order`: `asc` or `desc`. Defaults to `desc`.
+
+## Response
+
+Returns:
+
+- `success`: Boolean success flag.
+- `folders`: Array of folder objects.
+
+Each folder includes its attached `external_ids` array.
+
+## Notes
+
+- `created_by_email` only matches folders created after the migration that added creator tracking. Older folders without a recorded creator are excluded from that filter.
+
+## Example
+
+```bash
+curl -X GET "https://api.promptlayer.com/api/public/v2/folders?workspace_id=123&name=prod&sort_by=name&sort_order=asc" \
+  -H "X-API-KEY: your_api_key"
+```

--- a/reference/list-folders.mdx
+++ b/reference/list-folders.mdx
@@ -1,5 +1,6 @@
 ---
 title: "List Folders"
+openapi: "GET /api/public/v2/folders"
 ---
 
 Get a paginated list of folders in a workspace.

--- a/reference/list-input-variable-sets.mdx
+++ b/reference/list-input-variable-sets.mdx
@@ -1,0 +1,54 @@
+---
+title: "List Input Variable Sets"
+---
+
+Get a paginated list of input variable sets in a workspace.
+
+Use this endpoint when you want input variable sets only, rather than the mixed-entity response returned by [List Folder Entities](/reference/list-folder-entities).
+
+## Endpoint
+
+`GET /api/public/v2/input-variable-sets`
+
+## Authentication
+
+This endpoint requires API key authentication via the `X-API-KEY` header.
+
+## Query Parameters
+
+### Required
+
+- `workspace_id`: Workspace to query when your API key can access more than one workspace.
+
+### Filtering
+
+- `name`: Case-insensitive partial match on the input variable set name.
+- `created_by_email`: Return only input variable sets created by the matching user email.
+- `created_after` / `created_before`: Filter by creation timestamp.
+- `updated_after` / `updated_before`: Filter by last update timestamp.
+- `external_source` and `external_id`: Resolve a specific input variable set by its external ID mapping. These parameters must be provided together.
+
+### Sorting
+
+- `sort_by`: One of `created_at`, `updated_at`, `name`, or `id`.
+- `sort_order`: `asc` or `desc`. Defaults to `desc`.
+
+## Response
+
+Returns:
+
+- `success`: Boolean success flag.
+- `input_variable_sets`: Array of input variable set objects.
+
+Each input variable set includes its attached `external_ids` array.
+
+## Notes
+
+- `created_by_email` only matches input variable sets created after creator tracking was added. Older rows without a recorded creator are excluded from that filter.
+
+## Example
+
+```bash
+curl -X GET "https://api.promptlayer.com/api/public/v2/input-variable-sets?workspace_id=123&sort_by=updated_at&sort_order=desc" \
+  -H "X-API-KEY: your_api_key"
+```

--- a/reference/list-input-variable-sets.mdx
+++ b/reference/list-input-variable-sets.mdx
@@ -1,5 +1,6 @@
 ---
 title: "List Input Variable Sets"
+openapi: "GET /api/public/v2/input-variable-sets"
 ---
 
 Get a paginated list of input variable sets in a workspace.

--- a/reference/list-prompt-templates.mdx
+++ b/reference/list-prompt-templates.mdx
@@ -16,10 +16,11 @@ Each returned prompt template includes the latest version by default. When filte
 
 - **label**: Filter prompt templates by release label (e.g., `prod`, `dev`, `staging`). Returns the version associated with that label for each matching template.
 - **name**: Filter prompt templates by name (case-insensitive partial match)
+- **is_snippet**: When `true`, return only snippets. When `false`, exclude snippets. If omitted, both prompts and snippets are returned.
 - **tags**: Filter prompt templates by one or more tags. Can be provided as a single string or a list of strings. Only templates whose tags contain all specified values are returned.
 - **external_source** and **external_id**: Filter to the prompt template mapped to a specific external ID. These parameters must be provided together. If no mapping exists in the workspace, the endpoint returns an empty page.
 
-Each returned prompt template includes an `external_ids` array with the mappings attached to that prompt template. See [External IDs](/reference/external-ids-overview).
+Each returned prompt template includes an `external_ids` array with the mappings attached to that prompt template, as well as an `is_snippet` field so clients can distinguish reusable snippets from standard prompt templates. See [External IDs](/reference/external-ids-overview).
 
 ### Filtering by Status
 


### PR DESCRIPTION
## Summary
- add reference pages for the new public list endpoints for folders, AB tests, and input variable sets
- update unified registry docs for new entity types and shared filter/sort/external ID query params
- document `is_snippet` on list prompt templates and broaden the external IDs overview

## Why
`promptlayer-app` merged public API changes in #893 that expanded entity-list filtering and added standalone list endpoints, but the docs site did not yet cover those endpoints or the newer query behavior.

## Testing
- reviewed docs.json navigation updates
- reviewed rendered content structure in diff
