### PR TITLE
update Wrangler entry-point docs

### DIFF
--- a/features/skill-collections/editing-with-wrangler.mdx
+++ b/features/skill-collections/editing-with-wrangler.mdx
@@ -8,9 +8,7 @@ icon: "message-bot"
 
 ## Where to find Wrangler
 
-Open Wrangler from the **left sidebar** of the dashboard, then use the full chat pane when you want more room to work.
-
-![Wrangler AI button and chat pane](/images/skill-collections/wrangler-button.png)
+Open Wrangler from the **floating widget** in the bottom-right corner of the dashboard. Click the widget to expand the chat panel, then work from there when you need more room or want to keep Wrangler open while navigating the app.
 
 ## Mention a Skill Collection with `@`
 


### PR DESCRIPTION
## Summary
- update the Wrangler entry-point copy to match the floating widget UI
- remove the stale sidebar screenshot that no longer matches the product

## Why
Wrangler moved from the left sidebar to the floating widget, but the published docs still described the old entry point.

## Testing
- checked `origin/master` content for the published page
- reviewed the final doc diff
