### PR TITLE
docs: add Add Trace to Dataset to left nav (Reference > Datasets)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -242,6 +242,7 @@
                   "reference/create-dataset-version-from-filter-params",
                   "reference/create-draft-dataset-version",
                   "reference/add-request-log-to-dataset",
+                  "reference/add-trace-to-dataset",
                   "reference/save-draft-dataset-version",
                   "reference/external-ids-dataset-groups-attach",
                   "reference/external-ids-dataset-groups-list",


### PR DESCRIPTION
Adds `reference/add-trace-to-dataset` to the **Reference → REST API → Datasets** group in `docs.json`, positioned after `add-request-log-to-dataset`.

The reference page and OpenAPI spec entry were added in PR #297.

---
_Generated by [Claude Code](https://claude.ai/code/session_0172mVauzKquSwiVes7Ciqyg)_