### PR TITLE
Remove Claude tagging instruction from review guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,12 +61,6 @@ Avoid:
 
 ## Review Comments
 
-When leaving PR review comments, tag Claude directly:
-
-```md
-@claude <actionable review comment>
-```
-
 Keep comments specific, actionable, and tied to the docs guideline being enforced.
 
 ## Review Checklist


### PR DESCRIPTION
## What changed

Removed the instruction in `AGENTS.md` that told agents to tag Claude directly in every PR review comment, along with the `@claude <actionable review comment>` example.

The general guidance to keep review comments specific, actionable, and tied to the docs guidelines remains.

## Why

PR review guidance should not require automatically tagging Claude on every comment.

## Validation

- Confirmed `AGENTS.md` no longer contains `Claude` or `@claude`.
- Ran `git diff --cached --check` before committing.