### PR TITLE
Add May 19 changelog entries for Gemini 3.5 Flash and OTLP metadata ingestion

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -34,6 +34,26 @@ The Schema Editor now handles advanced JSON Schema patterns for structured outpu
 ---
 
 
+### Deployment 2
+
+#### New Features
+
+**Gemini 3.5 Flash Model Support**
+Added `gemini-3.5-flash`, Google's latest reasoning model built for speed.
+- 1M token context window with up to 65,536 output tokens
+- Supports text, image, video, and audio inputs with configurable reasoning
+- Available for both the Google and Vertex AI providers
+
+**OTLP Span Attribute Metadata Ingestion**
+OpenTelemetry traces now automatically populate request log metadata from standard span attributes — no separate `track.metadata()` call required.
+- `user.id` (or `enduser.id` as a deprecated fallback) maps to `user_id` metadata
+- `gen_ai.conversation.id` (or `session.id` as a fallback) maps to `conversation_id` metadata
+- `promptlayer.metadata.<key>` attributes map to arbitrary metadata key/value pairs on the request log
+- Explicit `promptlayer.metadata.*` attributes always take precedence over standard alias mappings
+
+---
+
+
 ## May 15, 2026
 
 ### Deployment 1


### PR DESCRIPTION
## Summary\n\nAdds changelog entries for two user-facing features shipped on May 19, 2026 that were missing from the changelog.\n\n**Gemini 3.5 Flash Model Support** (promptlayer-app PR #944)\n- New `gemini-3.5-flash` model added to Google provider and Vertex AI\n- 1M token context, 65K output tokens, multimodal (text/image/video/audio), reasoning support\n\n**OTLP Span Attribute Metadata Ingestion** (promptlayer-app PR #936)\n- OpenTelemetry spans now automatically populate request log metadata from standard attributes (`user.id`, `gen_ai.conversation.id`, `promptlayer.metadata.*`)\n- Eliminates the need for a separate `track.metadata()` REST call for OTLP users\n- The feature is already fully documented in `features/opentelemetry.mdx` (\"Attaching User Identity & Metadata\" section)\n\n## Notes\n\n- No other PRs from the May 19 batch required doc changes: the remaining merges were bug fixes, internal reliability improvements, or UI refactors with no new user-facing API or feature surface.\n- The opentelemetry.mdx page already contains complete documentation for the OTLP metadata feature; this PR only adds the changelog entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M112FF6ymCsWgdDdJZHb4z)_