### PR TITLE
Cross-reference OTLP metadata in the Metadata docs page

### DIFF
--- a/features/prompt-history/metadata.mdx
+++ b/features/prompt-history/metadata.mdx
@@ -90,3 +90,9 @@ Once metadata is added, you will then be able to see it in the web UI.
 ![score](/images/metadata-ui.png)
 
 Metadata is optimized for high-cardinality, request-specific values such as user IDs, session IDs, and error messages. For a smaller set of categories, such as environment, app, feature, or pipeline stage, use [tags](/features/prompt-history/tagging-requests) instead.
+
+## Attaching metadata via OpenTelemetry
+
+If you instrument your app with OpenTelemetry, you can attach metadata directly from span attributes — no `track.metadata()` call required. PromptLayer automatically maps standard attributes like `user.id` and `gen_ai.conversation.id`, and also reads arbitrary `promptlayer.metadata.<key>` attributes.
+
+See [Attaching User Identity & Metadata](/features/opentelemetry#attaching-user-identity-metadata) in the OpenTelemetry guide for details.


### PR DESCRIPTION
## Summary

- Adds a short "Attaching metadata via OpenTelemetry" section to `features/prompt-history/metadata.mdx` that points users to the full OTLP metadata guide.

## Context

PR [promptlayer-app#936](https://github.com/MagnivOrg/promptlayer-app/pull/936) shipped support for ingesting searchable metadata from OTLP span attributes (`user.id`, `gen_ai.conversation.id`, `promptlayer.metadata.*`, etc.). The feature is fully documented in `features/opentelemetry.mdx`, but users reading the Metadata page had no way to discover this alternative path. This change closes that discoverability gap with a brief cross-reference section.

No changelog update included per automation guidelines.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WesPFyrXFLqXrTZHCXP9xN)_