### PR TITLE
Fix broken anchor in OTLP metadata cross-reference link

### DIFF
--- a/features/prompt-history/metadata.mdx
+++ b/features/prompt-history/metadata.mdx
@@ -95,4 +95,4 @@ Metadata is optimized for high-cardinality, request-specific values such as user
 
 If you instrument your app with OpenTelemetry, you can attach metadata directly from span attributes — no `track.metadata()` call required. PromptLayer automatically maps standard attributes like `user.id` and `gen_ai.conversation.id`, and also reads arbitrary `promptlayer.metadata.<key>` attributes.
 
-See [Attaching User Identity & Metadata](/features/opentelemetry#attaching-user-identity-metadata) in the OpenTelemetry guide for details.
+See [Attaching User Identity & Metadata](/features/opentelemetry#attaching-user-identity-%26-metadata) in the OpenTelemetry guide for details.


### PR DESCRIPTION
## Summary

- Fixes the anchor in the "Attaching metadata via OpenTelemetry" section of `features/prompt-history/metadata.mdx`.

## Problem

The heading "Attaching User Identity & Metadata" on the OpenTelemetry page encodes the `&` as `%26` in the URL slug. The link added in #308 used `#attaching-user-identity-metadata` (dropping the ampersand entirely), which resolves to the top of the page instead of the correct section.

## Fix

Updated the anchor to `#attaching-user-identity-%26-metadata` to match the actual URL slug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WesPFyrXFLqXrTZHCXP9xN)_