### PR TITLE
Add dashboard navbar link

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -366,6 +366,10 @@
       {
         "label": "Contact Us",
         "href": "mailto:hello@promptlayer.com"
+      },
+      {
+        "label": "Dashboard",
+        "href": "https://dashboard.promptlayer.com"
       }
     ]
   },


### PR DESCRIPTION
## Summary
- Add a plain `Dashboard` link to the top navbar
- Point the link to `https://dashboard.promptlayer.com`
- Keep the link styled like the existing `Changelog` and `Contact Us` navbar links

## Validation
- `jq empty docs.json`
- `jq empty openapi.json`
- `mint broken-links`
- `mint validate`
- Browser preview checked `/overview` and `/quickstart` for plain navbar-link rendering

## Notes
- Removed the prior primary CTA styling approach before committing; this PR only changes `docs.json`.