### PR TITLE
Add ISO 8601 date-time format to tool registry timestamp fields

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -7271,10 +7271,12 @@
                             "nullable": true
                           },
                           "created_at": {
-                            "type": "string"
+                            "type": "string",
+                            "format": "date-time"
                           },
                           "updated_at": {
-                            "type": "string"
+                            "type": "string",
+                            "format": "date-time"
                           },
                           "external_ids": {
                             "type": "array",
@@ -7582,6 +7584,14 @@
                         },
                         "workspace_id": {
                           "type": "integer"
+                        },
+                        "created_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "updated_at": {
+                          "type": "string",
+                          "format": "date-time"
                         },
                         "labels": {
                           "type": "array",


### PR DESCRIPTION
Tool registry API responses now return timestamps as ISO 8601 strings (e.g. `2026-05-21T15:54:28.961051`) following the migration of tool registry endpoints to Pydantic serialization.

## Changes

- `GET /api/public/v2/tool-registry`: Added `"format": "date-time"` to `created_at` and `updated_at` in the response schema for items in the `tool_registries` array
- `GET /api/public/v2/tool-registry/{identifier}`: Added `created_at` and `updated_at` fields (with `"format": "date-time"`) to the `tool_registry` response object, which were missing from the spec despite being returned by the API

These changes align the tool registry schema with all other entity schemas in the spec (e.g. `Evaluation`, `Folder`, `SkillCollection`) which already annotate timestamps with `format: date-time`.

https://claude.ai/code/session_01MipGjubYjsLwydUSmQx82j

---
_Generated by [Claude Code](https://claude.ai/code/session_01MipGjubYjsLwydUSmQx82j)_