### PR TITLE
Add gpt-image-2 to supported image generation models

### DIFF
--- a/features/image-generation.mdx
+++ b/features/image-generation.mdx
@@ -11,7 +11,7 @@ Image generation is available through three distinct paths:
 
 | Provider | API / Method | Models | Template Type |
 |----------|-------------|--------|---------------|
-| **OpenAI** | Images API | `dall-e-2`, `dall-e-3`, `gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5` | Completion |
+| **OpenAI** | Images API | `dall-e-2`, `dall-e-3`, `gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2` | Completion |
 | **OpenAI** | Responses API (`image_generation` tool) | `gpt-5`, `gpt-5.4`, `gpt-5.2`, `gpt-5-nano`, `gpt-4.1`, and [other supported models](https://developers.openai.com/api/docs/guides/tools-image-generation#supported-models) | Chat |
 | **OpenAI Azure** | Images API | Same as OpenAI (depends on Azure deployment) | Completion |
 | **OpenAI Azure** | Responses API (`image_generation` tool) | Same as OpenAI Responses API | Chat |
@@ -95,7 +95,7 @@ for (const item of content) {
 
 ### Pricing
 
-GPT Image models (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`) use **token-based pricing** — cost is calculated from input and output tokens, just like text models. PromptLayer automatically tracks these tokens and calculates cost.
+GPT Image models (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`) use **token-based pricing** — cost is calculated from input and output tokens, just like text models. PromptLayer automatically tracks these tokens and calculates cost.
 
 DALL-E models (`dall-e-2`, `dall-e-3`) use **per-image pricing** based on the image size and model. PromptLayer tracks this automatically.
 

--- a/features/supported-providers.mdx
+++ b/features/supported-providers.mdx
@@ -12,7 +12,7 @@ Below is the list of LLM providers supported in PromptLayer along with key capab
 
 - Chat Completions, Responses API, and Images API are all supported.
 - Function/Tool Calling (including built-in Responses API tools: Web Search, File Search, Image Generation) — see [Tool Calling](/features/prompt-registry/tool-calling).
-- **Image Generation** via three paths: Images API (`dall-e-2`, `dall-e-3`, `gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`), Responses API `image_generation` tool, and GPT Image models — see [Image Generation](/features/image-generation).
+- **Image Generation** via three paths: Images API (`dall-e-2`, `dall-e-3`, `gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`), Responses API `image_generation` tool, and GPT Image models — see [Image Generation](/features/image-generation).
 - JSON mode / structured outputs.
 - Vision models (e.g., `gpt-4-vision`) — see [FAQ: multimodal](/features/faq#does-promptlayer-support-multi-modal-image-models-like-gpt-4-vision).
 - Streaming via SDK (Python/JS).


### PR DESCRIPTION
Adds `gpt-image-2` to the list of supported OpenAI Images API models across the image generation documentation.\n\n## Changes\n\n- `features/image-generation.mdx`: Added `gpt-image-2` to the supported models table (Images API row) and to the token-based pricing model list.\n- `features/supported-providers.mdx`: Added `gpt-image-2` to the OpenAI Images API model list.\n\n`gpt-image-2` is OpenAI's most capable image generation model with 4K output support and intelligent routing. It uses token-based pricing like other GPT Image models.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3pkrrKYGpmx6fQ4fpUiLq)_