### PR TITLE
Add OpenAI Agents SDK span capture summary

### DIFF
--- a/features/integrations.mdx
+++ b/features/integrations.mdx
@@ -167,6 +167,8 @@ tracer_provider.shutdown()
 - `OPENAI_API_KEY`
 - `PROMPTLAYER_API_KEY`
 
+Once configured, PromptLayer will capture OpenAI Agents traces with spans automatically labeled by type: agent spans appear as **LLM session**, response and generation spans appear as **LLM call**, and function/tool spans appear as **Tool: \<function name\>**. Token usage, model metadata, prompts, and completions are captured from LLM call spans.
+
 ## Vercel AI SDK
 
 PromptLayer supports integration with the [Vercel AI SDK](https://ai-sdk.dev/docs), allowing you to export OpenTelemetry traces from your application directly to PromptLayer.


### PR DESCRIPTION
The OpenAI Agents SDK integration page now ends with a clear summary of what PromptLayer captures from agent traces, including how each span type is labeled in the trace viewer.

Agent spans appear as **LLM session**, response/generation spans appear as **LLM call**, and function/tool spans appear as **Tool: \<function name\>**. Token usage, model metadata, prompts, and completions are captured from LLM call spans.

This is consistent with how the Claude Code, Vercel AI SDK, Pydantic AI, and LangChain sections already end with a "Once configured, PromptLayer will capture…" summary.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnZDU3tcwRQgFpFfEz1D5A)_