### PR TITLE
Add sub_scores to custom scoring docs and document OpenAI-compat provider-specific params

### DIFF
--- a/features/evaluations/score-card.mdx
+++ b/features/evaluations/score-card.mdx
@@ -54,6 +54,7 @@ Your custom scoring code must return an object with the following keys:
 
 - `score` (required): A number representing the overall score. This is mandatory.
 - `score_matrix` (optional): A list of lists of lists, representing one or more matrices of drilled-down scores. Each cell in these matrices can be a raw value or an object with metadata.
+- `sub_scores` (optional): A dictionary mapping label names to numeric values. Sub-scores appear in the score card's drill-down breakdown panel, letting you break the overall score into named components (e.g., `{"correctness": 0.9, "relevance": 0.8}`).
 
 #### Score Matrix Cell Format
 
@@ -99,12 +100,17 @@ For example:
 #
 # Must return a dictionary with the following structure:
 # {
-#   'score': int,  # Required
-#   'score_matrix': [[[int, int, ...], ...]...],  # Optional - list of lists of lists of integers
+#   'score': int,           # Required
+#   'sub_scores': {...},    # Optional - named component scores (label -> number)
+#   'score_matrix': [[[int, int, ...], ...]...],  # Optional - list of lists of lists
 # }
 
 return {
     'score': len(data),
+    'sub_scores': {
+        'correctness': 0.85,
+        'completeness': 0.70,
+    },
     'score_matrix': [[
         ["Criteria", "Weight", "Value"],
         ["Correctness", 4, 7],

--- a/features/supported-providers.mdx
+++ b/features/supported-providers.mdx
@@ -115,6 +115,7 @@ Examples:
 Capabilities:
 - Works in Logs, Prompt Registry, and Playground.
 - Evaluations: supported when the provider's OpenAI-compat layer matches PromptLayer parameters; remove unsupported params if needed (e.g., some providers do not support "seed").
+- Provider-specific parameters not in the standard OpenAI SDK (e.g., `thinking` for Kimi/Moonshot) are automatically forwarded to the provider in the request body — no extra configuration needed.
 - Tool/Function Calling and streaming availability depend on the provider/model.
 
 ## Anthropic Prompt Caching
@@ -132,7 +133,7 @@ Set a cache duration in the **Advanced Model Controls** (Prompt Caching dropdown
 Available durations:
 
 | Duration | Providers |
-|----------|-----------|
+|----------|----------|
 | **5 minutes** | Anthropic, Vertex AI, Amazon Bedrock (all supported Claude models) |
 | **1 hour** | Anthropic, Vertex AI, Amazon Bedrock (Claude Sonnet 4.5 only) |
 


### PR DESCRIPTION
## Summary

- Documents the `sub_scores` return key for custom scoring logic in evaluation score cards. Custom scorers can return a `sub_scores` dictionary (label → number) that populates the score card's drill-down breakdown panel. Updates the return-key reference list and code example in `score-card.mdx`.
- Documents that provider-specific parameters not in the standard OpenAI SDK (e.g., `thinking` for Kimi/Moonshot) are automatically forwarded to the provider in the request body when using OpenAI-compatible custom providers. Adds a bullet to the Capabilities section in `supported-providers.mdx`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9q1FfW71BX3pjuzwUU1Vz)_