### PR TITLE
Environment variables for auto-executing tools

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -321,6 +321,20 @@
                 ]
               },
               {
+                "group": "Environment Variables",
+                "tag": "New",
+                "pages": [
+                  "reference/env-vars-workspace-list",
+                  "reference/env-vars-workspace-create",
+                  "reference/env-vars-workspace-update",
+                  "reference/env-vars-workspace-delete",
+                  "reference/env-vars-tool-list",
+                  "reference/env-vars-tool-create",
+                  "reference/env-vars-tool-update",
+                  "reference/env-vars-tool-delete"
+                ]
+              },
+              {
                 "group": "Tables",
                 "tag": "New",
                 "pages": [

--- a/features/tool-registry/auto-execution.mdx
+++ b/features/tool-registry/auto-execution.mdx
@@ -141,7 +141,7 @@ const apiKey = process.env.MY_API_KEY;
 
 Values are encrypted at rest and only the last 4 characters are shown in the UI. Variables are injected into the sandbox process at runtime and never appear in the versioned source code.
 
-You can also create and list env vars through the [public API](/api-reference/env-vars/list-workspace-env-vars).
+You can also create and list env vars through the [public API](/reference/env-vars-workspace-list).
 
 ## Sandbox & Security
 

--- a/features/tool-registry/auto-execution.mdx
+++ b/features/tool-registry/auto-execution.mdx
@@ -116,12 +116,39 @@ The loop is capped at 10 LLM calls per request to prevent runaway loops. If the 
 
 This split keeps the LLM resilient to expected errors (bad args, missing keys) but lets infrastructure failures surface so you can see and fix them.
 
+## Environment Variables
+
+Execution bodies often need secrets — API keys, tokens, connection strings — that shouldn't be hard-coded in the editor (editor content is versioned and visible to anyone with workspace access).
+
+Use **environment variables** to inject secrets at execution time. There are two scopes:
+
+- **Workspace env vars** — shared across all tools in the workspace. Set them once in **Settings → Environment Variables**.
+- **Tool env vars** — scoped to a specific tool. Set them in the tool's **Configure** dialog. Tool-level values override workspace-level values when the same key exists in both.
+
+Inside an execution body, read them with the standard runtime API:
+
+<CodeGroup>
+```python Python
+import os
+
+api_key = os.environ["MY_API_KEY"]
+```
+
+```javascript JavaScript
+const apiKey = process.env.MY_API_KEY;
+```
+</CodeGroup>
+
+Values are encrypted at rest and only the last 4 characters are shown in the UI. Variables are injected into the sandbox process at runtime and never appear in the versioned source code.
+
+You can also create and list env vars through the [public API](/api-reference/env-vars/list-workspace-env-vars).
+
 ## Sandbox & Security
 
 Execution bodies run in an isolated sandbox per request. Each invocation gets a fresh process: no shared state between calls, no access to your application's environment or filesystem. Standard libraries plus the common Python/JS ecosystem are available.
 
 <Warning>
-The execution body is your code. Treat it like production code. Anything secret it needs (API keys, etc.) must be injected via your tool's logic, not hard-coded in the body. Hardcoded secrets in the editor are versioned and visible to anyone with workspace access.
+The execution body is your code. Treat it like production code. Never hard-code secrets directly in the body — use [environment variables](#environment-variables) instead.
 </Warning>
 
 ## Enabling Auto Execution

--- a/openapi.json
+++ b/openapi.json
@@ -7515,7 +7515,7 @@
                       },
                       "code": {
                         "type": "string",
-                        "description": "The function BODY only — the signature `def <name>(args):` (Python) or `function <name>(args) { ... }` (JavaScript) is generated automatically. The LLM's arguments arrive as a single `args` object."
+                        "description": "The function BODY only \u2014 the signature `def <name>(args):` (Python) or `function <name>(args) { ... }` (JavaScript) is generated automatically. The LLM's arguments arrive as a single `args` object."
                       }
                     }
                   }
@@ -7655,7 +7655,7 @@
                         "version": {
                           "type": "object",
                           "nullable": true,
-                          "description": "Resolved version object — includes `tool_definition` and (if set) `execution: { type, language, code }`."
+                          "description": "Resolved version object \u2014 includes `tool_definition` and (if set) `execution: { type, language, code }`."
                         },
                         "tool_definition": {
                           "type": "object",
@@ -11125,7 +11125,7 @@
                           },
                           "cells": {
                             "type": "object",
-                            "description": "Map of column_id (UUID string) → cell object.",
+                            "description": "Map of column_id (UUID string) \u2192 cell object.",
                             "additionalProperties": {
                               "$ref": "#/components/schemas/Cell"
                             }
@@ -11216,7 +11216,7 @@
                 "properties": {
                   "count": {
                     "type": "integer",
-                    "description": "Number of rows to append (1–100).",
+                    "description": "Number of rows to append (1\u2013100).",
                     "default": 1,
                     "minimum": 1,
                     "maximum": 100
@@ -11224,7 +11224,7 @@
                   "values": {
                     "type": "array",
                     "nullable": true,
-                    "description": "Per-row initial values for text columns. Each element is a map of column_id → value.",
+                    "description": "Per-row initial values for text columns. Each element is a map of column_id \u2192 value.",
                     "items": {
                       "type": "object",
                       "additionalProperties": true
@@ -11760,7 +11760,7 @@
                       },
                       "code": {
                         "type": "string",
-                        "description": "The function BODY only — the signature `def <name>(args):` (Python) or `function <name>(args) { ... }` (JavaScript) is generated automatically. LLM arguments arrive as a single `args` object."
+                        "description": "The function BODY only \u2014 the signature `def <name>(args):` (Python) or `function <name>(args) { ... }` (JavaScript) is generated automatically. LLM arguments arrive as a single `args` object."
                       }
                     }
                   },
@@ -11853,7 +11853,7 @@
                 "properties": {
                   "inputs": {
                     "type": "object",
-                    "description": "Arguments passed to the tool body. Same shape the LLM would emit — keys match the tool's parameter names.",
+                    "description": "Arguments passed to the tool body. Same shape the LLM would emit \u2014 keys match the tool's parameter names.",
                     "additionalProperties": true
                   },
                   "execution": {
@@ -11896,7 +11896,7 @@
         },
         "responses": {
           "200": {
-            "description": "Tool executed (success or user-code error). User-code errors return status=\"error\" inside the result object — they do NOT raise.",
+            "description": "Tool executed (success or user-code error). User-code errors return status=\"error\" inside the result object \u2014 they do NOT raise.",
             "content": {
               "application/json": {
                 "schema": {
@@ -12074,6 +12074,776 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/api/public/v2/env-vars": {
+      "get": {
+        "tags": [
+          "env-vars"
+        ],
+        "summary": "List Workspace Env Vars",
+        "operationId": "list_workspace_env_vars",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "workspace_env_vars": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer"
+                          },
+                          "key": {
+                            "type": "string"
+                          },
+                          "value_suffix": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "Last 4 characters of the stored value. Null or empty when the value is empty."
+                          },
+                          "is_empty": {
+                            "type": "boolean",
+                            "description": "True when the value has not been set yet (placeholder created by the AI assistant)."
+                          },
+                          "created_at": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "updated_at": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "workspace_id": {
+                            "type": "integer",
+                            "description": "Present on workspace-scoped env vars."
+                          },
+                          "tool_registry_id": {
+                            "type": "integer",
+                            "description": "Present on tool-scoped env vars."
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "env-vars"
+        ],
+        "summary": "Create Workspace Env Var",
+        "operationId": "create_workspace_env_var",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "key"
+                ],
+                "properties": {
+                  "key": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 255,
+                    "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+                    "description": "Environment variable name. Must start with a letter or underscore and contain only letters, digits, and underscores."
+                  },
+                  "value": {
+                    "type": "string",
+                    "maxLength": 8192,
+                    "description": "Value to store. May be empty to create a placeholder that the user will fill in later."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "workspace_env_var": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        },
+                        "key": {
+                          "type": "string"
+                        },
+                        "value_suffix": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "Last 4 characters of the stored value. Null or empty when the value is empty."
+                        },
+                        "is_empty": {
+                          "type": "boolean",
+                          "description": "True when the value has not been set yet (placeholder created by the AI assistant)."
+                        },
+                        "created_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "updated_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "workspace_id": {
+                          "type": "integer",
+                          "description": "Present on workspace-scoped env vars."
+                        },
+                        "tool_registry_id": {
+                          "type": "integer",
+                          "description": "Present on tool-scoped env vars."
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "An environment variable with that key already exists in this workspace.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError"
+          }
+        }
+      }
+    },
+    "/api/public/v2/env-vars/{var_id}": {
+      "patch": {
+        "tags": [
+          "env-vars"
+        ],
+        "summary": "Update Workspace Env Var",
+        "operationId": "update_workspace_env_var",
+        "parameters": [
+          {
+            "name": "var_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "value"
+                ],
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 8192,
+                    "description": "New value for the environment variable. Must be non-empty."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "workspace_env_var": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        },
+                        "key": {
+                          "type": "string"
+                        },
+                        "value_suffix": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "Last 4 characters of the stored value. Null or empty when the value is empty."
+                        },
+                        "is_empty": {
+                          "type": "boolean",
+                          "description": "True when the value has not been set yet (placeholder created by the AI assistant)."
+                        },
+                        "created_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "updated_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "workspace_id": {
+                          "type": "integer",
+                          "description": "Present on workspace-scoped env vars."
+                        },
+                        "tool_registry_id": {
+                          "type": "integer",
+                          "description": "Present on tool-scoped env vars."
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workspace env var not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "env-vars"
+        ],
+        "summary": "Delete Workspace Env Var",
+        "operationId": "delete_workspace_env_var",
+        "parameters": [
+          {
+            "name": "var_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workspace env var not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError"
+          }
+        }
+      }
+    },
+    "/api/public/v2/tool-registry/{identifier}/env-vars": {
+      "get": {
+        "tags": [
+          "env-vars",
+          "tool-registry"
+        ],
+        "summary": "List Tool Env Vars",
+        "operationId": "list_tool_env_vars",
+        "parameters": [
+          {
+            "name": "identifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Tool ID (numeric) or name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "tool_env_vars": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer"
+                          },
+                          "key": {
+                            "type": "string"
+                          },
+                          "value_suffix": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "Last 4 characters of the stored value. Null or empty when the value is empty."
+                          },
+                          "is_empty": {
+                            "type": "boolean",
+                            "description": "True when the value has not been set yet (placeholder created by the AI assistant)."
+                          },
+                          "created_at": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "updated_at": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "workspace_id": {
+                            "type": "integer",
+                            "description": "Present on workspace-scoped env vars."
+                          },
+                          "tool_registry_id": {
+                            "type": "integer",
+                            "description": "Present on tool-scoped env vars."
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Tool not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "env-vars",
+          "tool-registry"
+        ],
+        "summary": "Create Tool Env Var",
+        "operationId": "create_tool_env_var",
+        "parameters": [
+          {
+            "name": "identifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Tool ID (numeric) or name"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "key"
+                ],
+                "properties": {
+                  "key": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 255,
+                    "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+                    "description": "Environment variable name. Must start with a letter or underscore and contain only letters, digits, and underscores."
+                  },
+                  "value": {
+                    "type": "string",
+                    "maxLength": 8192,
+                    "description": "Value to store. May be empty to create a placeholder that the user will fill in later."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "tool_env_var": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        },
+                        "key": {
+                          "type": "string"
+                        },
+                        "value_suffix": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "Last 4 characters of the stored value. Null or empty when the value is empty."
+                        },
+                        "is_empty": {
+                          "type": "boolean",
+                          "description": "True when the value has not been set yet (placeholder created by the AI assistant)."
+                        },
+                        "created_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "updated_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "workspace_id": {
+                          "type": "integer",
+                          "description": "Present on workspace-scoped env vars."
+                        },
+                        "tool_registry_id": {
+                          "type": "integer",
+                          "description": "Present on tool-scoped env vars."
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Tool not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "An environment variable with that key already exists on this tool.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError"
+          }
+        }
+      }
+    },
+    "/api/public/v2/tool-registry/{identifier}/env-vars/{var_id}": {
+      "patch": {
+        "tags": [
+          "env-vars",
+          "tool-registry"
+        ],
+        "summary": "Update Tool Env Var",
+        "operationId": "update_tool_env_var",
+        "parameters": [
+          {
+            "name": "identifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Tool ID (numeric) or name"
+            }
+          },
+          {
+            "name": "var_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "value"
+                ],
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 8192,
+                    "description": "New value for the environment variable. Must be non-empty."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "tool_env_var": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        },
+                        "key": {
+                          "type": "string"
+                        },
+                        "value_suffix": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "Last 4 characters of the stored value. Null or empty when the value is empty."
+                        },
+                        "is_empty": {
+                          "type": "boolean",
+                          "description": "True when the value has not been set yet (placeholder created by the AI assistant)."
+                        },
+                        "created_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "updated_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "workspace_id": {
+                          "type": "integer",
+                          "description": "Present on workspace-scoped env vars."
+                        },
+                        "tool_registry_id": {
+                          "type": "integer",
+                          "description": "Present on tool-scoped env vars."
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Tool or env var not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "env-vars",
+          "tool-registry"
+        ],
+        "summary": "Delete Tool Env Var",
+        "operationId": "delete_tool_env_var",
+        "parameters": [
+          {
+            "name": "identifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Tool ID (numeric) or name"
+            }
+          },
+          {
+            "name": "var_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Tool or env var not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError"
           }
         }
       }
@@ -18284,7 +19054,7 @@
       "RequestLogQuery": {
         "type": "object",
         "title": "RequestLogQuery",
-        "description": "Canonical request-log query payload — the filter / search / sort fields shared by `POST /api/public/v2/requests/search` (which also accepts pagination + `include_prompt_name`) and `POST /api/public/v2/requests/analytics`.",
+        "description": "Canonical request-log query payload \u2014 the filter / search / sort fields shared by `POST /api/public/v2/requests/search` (which also accepts pagination + `include_prompt_name`) and `POST /api/public/v2/requests/analytics`.",
         "properties": {
           "filter_group": {
             "nullable": true,
@@ -18536,7 +19306,7 @@
       "RequestAnalyticsResponse": {
         "type": "object",
         "title": "RequestAnalyticsResponse",
-        "description": "Aggregated analytics across the matching request logs. Bucket size is selected automatically based on the filter time range (seconds → minutes → hours → days).",
+        "description": "Aggregated analytics across the matching request logs. Bucket size is selected automatically based on the filter time range (seconds \u2192 minutes \u2192 hours \u2192 days).",
         "required": [
           "success"
         ],
@@ -18604,7 +19374,7 @@
           },
           "modelRequestsByDay": {
             "type": "object",
-            "description": "Map of model name → list of `[date, requestCount]` pairs.",
+            "description": "Map of model name \u2192 list of `[date, requestCount]` pairs.",
             "additionalProperties": {
               "type": "array",
               "items": {
@@ -20495,7 +21265,7 @@
       },
       "Table": {
         "type": "object",
-        "description": "A Table — a versioned, multi-sheet table that can run LLM columns to generate or evaluate data at scale.",
+        "description": "A Table \u2014 a versioned, multi-sheet table that can run LLM columns to generate or evaluate data at scale.",
         "properties": {
           "id": {
             "type": "string",
@@ -20536,7 +21306,7 @@
         "properties": {
           "sheet_row_counts": {
             "type": "object",
-            "description": "Map of sheet_id → row count.",
+            "description": "Map of sheet_id \u2192 row count.",
             "additionalProperties": {
               "type": "integer"
             }

--- a/reference/env-vars-tool-create.mdx
+++ b/reference/env-vars-tool-create.mdx
@@ -1,0 +1,6 @@
+---
+title: "Create Tool Env Var"
+openapi: "POST /api/public/v2/tool-registry/{identifier}/env-vars"
+---
+
+Create a tool-scoped environment variable. Tool-level variables take precedence over workspace-level variables with the same key when the tool executes.

--- a/reference/env-vars-tool-delete.mdx
+++ b/reference/env-vars-tool-delete.mdx
@@ -1,0 +1,6 @@
+---
+title: "Delete Tool Env Var"
+openapi: "DELETE /api/public/v2/tool-registry/{identifier}/env-vars/{var_id}"
+---
+
+Permanently delete a tool-scoped environment variable.

--- a/reference/env-vars-tool-list.mdx
+++ b/reference/env-vars-tool-list.mdx
@@ -1,0 +1,6 @@
+---
+title: "List Tool Env Vars"
+openapi: "GET /api/public/v2/tool-registry/{identifier}/env-vars"
+---
+
+List all environment variables scoped to a specific tool. Tool-level variables override workspace-level variables with the same key at execution time.

--- a/reference/env-vars-tool-update.mdx
+++ b/reference/env-vars-tool-update.mdx
@@ -1,0 +1,6 @@
+---
+title: "Update Tool Env Var"
+openapi: "PATCH /api/public/v2/tool-registry/{identifier}/env-vars/{var_id}"
+---
+
+Update the value of a tool-scoped environment variable. The new value must be non-empty.

--- a/reference/env-vars-workspace-create.mdx
+++ b/reference/env-vars-workspace-create.mdx
@@ -1,0 +1,6 @@
+---
+title: "Create Workspace Env Var"
+openapi: "POST /api/public/v2/env-vars"
+---
+
+Create a workspace-scoped environment variable. The key must be a valid identifier (`^[A-Za-z_][A-Za-z0-9_]*$`). The value may be empty to create a placeholder that the user fills in later via the Settings UI.

--- a/reference/env-vars-workspace-delete.mdx
+++ b/reference/env-vars-workspace-delete.mdx
@@ -1,0 +1,6 @@
+---
+title: "Delete Workspace Env Var"
+openapi: "DELETE /api/public/v2/env-vars/{var_id}"
+---
+
+Permanently delete a workspace-scoped environment variable.

--- a/reference/env-vars-workspace-list.mdx
+++ b/reference/env-vars-workspace-list.mdx
@@ -1,0 +1,6 @@
+---
+title: "List Workspace Env Vars"
+openapi: "GET /api/public/v2/env-vars"
+---
+
+List all environment variables in the workspace scope. Values are not returned — only the key, a 4-character suffix for display, and an `is_empty` flag.

--- a/reference/env-vars-workspace-update.mdx
+++ b/reference/env-vars-workspace-update.mdx
@@ -1,0 +1,6 @@
+---
+title: "Update Workspace Env Var"
+openapi: "PATCH /api/public/v2/env-vars/{var_id}"
+---
+
+Update the value of a workspace-scoped environment variable. The new value must be non-empty.


### PR DESCRIPTION
## Summary

- Documents the new environment variables API for workspace- and tool-scoped secrets, allowing API keys and tokens to be injected into sandbox tool executions without hard-coding them in the execution body
- Adds 8 new OpenAPI spec entries covering the full CRUD surface: `GET/POST /api/public/v2/env-vars`, `PATCH/DELETE /api/public/v2/env-vars/{var_id}`, and the tool-scoped equivalents under `/api/public/v2/tool-registry/{identifier}/env-vars`
- Adds 8 reference pages wired to the new OpenAPI operations and registers them in the "Environment Variables" group in docs.json
- Updates the Auto Tool Execution page to explain how to use env vars for secrets (workspace-scoped and tool-scoped), replacing the previous guidance that simply warned against hardcoding secrets

## Test plan

- [ ] Verify the new "Environment Variables" group appears in the REST API reference sidebar
- [ ] Confirm each reference page renders the correct request/response schema from the OpenAPI spec
- [ ] Review the updated "Sandbox & Security" section on the Auto Tool Execution page

https://claude.ai/code/session_01SqcZvbeNWk4Lsrtk7GXgpt

---
_Generated by [Claude Code](https://claude.ai/code/session_01SqcZvbeNWk4Lsrtk7GXgpt)_