### PR TITLE
docs(tables): remove STATIC column type from Tables docs

### DIFF
--- a/features/tables/column-types.mdx
+++ b/features/tables/column-types.mdx
@@ -25,7 +25,6 @@ Computed columns read from source columns in the sheet. For example, a `Prompt o
 | Endpoint | `ENDPOINT` | Data source / execution | You want to send row data to an external URL endpoint. |
 | MCP | `MCP` | Data source / execution | You want to call Model Context Protocol server functions. |
 | Conversation Simulator | `CONVERSATION_SIMULATOR` | Data source / execution | You want to simulate a multi-turn user and assistant conversation. |
-| Static | `VARIABLE` | Data source / execution | You need a static value available as an input. |
 | Human | `HUMAN` | Data source / execution | You need a human to fill in or approve data. |
 | While Loop | `WHILE_LOOP` | Data source / execution | You need repeated execution while a condition remains true. |
 | For Loop | `FOR_LOOP` | Data source / execution | You need to iterate over a collection or array. |


### PR DESCRIPTION
## Summary
- remove the Static (VARIABLE) row from the Tables column type overview
- keep workflow/evaluation docs unchanged since STATIC remains workflow-only

## Why
STATIC is only available in workflows and should not appear in Tables column type docs.