### PR TITLE
Fix scorecard docs schema accuracy

### DIFF
--- a/features/tables/scorecards.mdx
+++ b/features/tables/scorecards.mdx
@@ -139,7 +139,7 @@ client = PromptLayer(api_key="pl_your_key")
 table_id = "00000000-0000-0000-0000-000000000000"
 sheet_id = "11111111-1111-1111-1111-111111111111"
 
-client.tables.sheets.scorecards.configure_scorecard(
+client.tables.sheets.scorecards.configure(
     table_id,
     sheet_id,
     {

--- a/openapi.json
+++ b/openapi.json
@@ -24761,8 +24761,23 @@
             "items": {
               "type": "string"
             }
+          },
+          "stale_step_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "stale_row_indices": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "minimum": 0
+            }
           }
-        }
+        },
+        "additionalProperties": true
       },
       "TableSheetScorecardAggregation": {
         "type": "object",
@@ -24781,7 +24796,7 @@
             "enum": [
               "fail",
               "warn",
-              "ignore"
+              "error"
             ]
           },
           "pass_threshold": {
@@ -24850,6 +24865,47 @@
             "type": "object",
             "nullable": true,
             "additionalProperties": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "target_column_id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "evidence_mode": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "summary",
+              "raw",
+              "hidden",
+              null
+            ]
+          },
+          "order_index": {
+            "type": "integer"
+          },
+          "backing_column_id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "config_hash": {
+            "type": "string",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
           }
         },
         "additionalProperties": true
@@ -24921,7 +24977,12 @@
             ]
           },
           "stale_state": {
-            "$ref": "#/components/schemas/TableSheetScorecardStaleState"
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TableSheetScorecardStaleState"
+              }
+            ]
           },
           "latest_calculation_id": {
             "type": "string",
@@ -25029,9 +25090,8 @@
             "nullable": true
           },
           "error_summary": {
-            "type": "object",
-            "nullable": true,
-            "additionalProperties": true
+            "type": "string",
+            "nullable": true
           }
         },
         "additionalProperties": true
@@ -25041,10 +25101,7 @@
         "required": [
           "success",
           "scorecard",
-          "latest_calculation",
-          "display_calculation",
-          "criterion_summaries",
-          "drift_summary"
+          "latest_calculation"
         ],
         "properties": {
           "success": {
@@ -25082,6 +25139,23 @@
           "drift_summary": {
             "type": "object",
             "nullable": true,
+            "additionalProperties": true
+          },
+          "progress": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "scored_rows": {
+                "type": "integer"
+              },
+              "total_rows": {
+                "type": "integer"
+              },
+              "partial_score": {
+                "type": "number",
+                "nullable": true
+              }
+            },
             "additionalProperties": true
           }
         },
@@ -25185,7 +25259,12 @@
             "type": "boolean"
           },
           "scorecard": {
-            "$ref": "#/components/schemas/TableSheetScorecard"
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TableSheetScorecard"
+              }
+            ]
           },
           "converted_count": {
             "type": "integer"
@@ -25404,9 +25483,8 @@
             "additionalProperties": true
           },
           "error_summary": {
-            "type": "object",
-            "nullable": true,
-            "additionalProperties": true
+            "type": "string",
+            "nullable": true
           }
         },
         "additionalProperties": true
@@ -25426,7 +25504,8 @@
           },
           "calculation_id": {
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "nullable": true
           },
           "rows": {
             "type": "array",
@@ -25521,9 +25600,8 @@
             "additionalProperties": true
           },
           "error_summary": {
-            "type": "object",
-            "nullable": true,
-            "additionalProperties": true
+            "type": "string",
+            "nullable": true
           },
           "config_hash": {
             "type": "string",

--- a/scorecard-api/TABLE_SCORECARDS_PUBLIC_API_HANDOFF.md
+++ b/scorecard-api/TABLE_SCORECARDS_PUBLIC_API_HANDOFF.md
@@ -932,7 +932,7 @@ scorecard = response["scorecard"]
 ### Configure scorecard
 
 ```python
-response = client.tables.sheets.scorecards.configure_scorecard(
+response = client.tables.sheets.scorecards.configure(
     table_id,
     sheet_id,
     {


### PR DESCRIPTION
## Summary
- Align scorecard OpenAPI schemas with backend behavior for required fields, nullability, enums, and error summary types
- Document scorecard progress and scoped stale state fields returned by the backend
- Fix Python SDK manager examples to use scorecards.configure(...), which matches the SDK manager API

## Validation
- Ran python3 -m json.tool on openapi.json
- Checked scorecard docs for stale configure_scorecard manager references