### PR TITLE
Update SDK evals docs for column structure and scorer APIs

### DIFF
--- a/sdks/evals/agent-tracing.mdx
+++ b/sdks/evals/agent-tracing.mdx
@@ -33,7 +33,7 @@ You don't create those spans by hand. Emit them with either:
 - **A framework helper** — OpenAI Agents, Claude, Vercel AI, and the rest in [Telemetry Integrations](/features/integrations) — which instruments your tools automatically.
 - **`traceTool`** on a custom agent's tool handlers. It records the `Tool: <name>` span for you (on a tracing-enabled client); see [Tracing Tools](/running-requests/traces#tracing-tools) for the full contract.
 
-Only the tools you assert on (the names in `accepted_scenarios`) need a span — a helper tool you don't score can stay untraced. How the modes treat what they observe:
+Only the tools you assert on (the names in Trajectory `expected`) need a span — a helper tool you don't score can stay untraced. How the modes treat what they observe:
 
 | `mode` | Rule | Untraced / extra tools |
 | --- | --- | --- |

--- a/sdks/evals/building-an-eval.mdx
+++ b/sdks/evals/building-an-eval.mdx
@@ -43,9 +43,10 @@ Cases feed the runner and scorers. [Datasets](/sdks/evals/datasets) covers inlin
 
 | Field | Required | Purpose |
 | --- | --- | --- |
-| `input` | ✅ | Passed to the `runner`. |
-| `expected` | — | Expected **output** (used by Contains, Compare, …). |
+| `input` | ✅ | Passed to the `runner` (column `input`). |
+| `expected` | — | Expected **output** for Contains, Compare, … (column `expected`). |
 | `expected_trace` / `expectedTrace` | — | [Trajectory](/sdks/evals/scorers/overview#trajectory) config — which tools should run, not the answer text. |
+| other keys | — | Custom TEXT columns (exact title). No reserved or supporting-column name collisions. |
 
 ## Runner
 

--- a/sdks/evals/columns/overview.mdx
+++ b/sdks/evals/columns/overview.mdx
@@ -77,8 +77,8 @@ evaluate(
     ],
     scorers=[
         compare_scorer(
-            source="Prompt output",
-            value_source="expected",
+            source_column="Prompt output",
+            expected_column="expected",
         )
     ],
 )
@@ -115,8 +115,8 @@ await evaluate("prompt-column-demo", {
   ],
   scorers: [
     compareScorer({
-      source: "Prompt output",
-      valueSource: "expected",
+      sourceColumn: "Prompt output",
+      expectedColumn: "expected",
     }),
   ],
 });
@@ -167,7 +167,7 @@ evaluate(
             {"source": "Output", "json_path": "$.user.id", "return_first_match": True},
         )
     ],
-    scorers=[contains_scorer(source="User id", value="42")],
+    scorers=[contains_scorer(source_column="User id", expected="42")],
 )
 ```
 
@@ -202,7 +202,7 @@ await evaluate("json-path-demo", {
       return_first_match: true,
     }),
   ],
-  scorers: [containsScorer({ source: "User id", value: "42" })],
+  scorers: [containsScorer({ sourceColumn: "User id", expected: "42" })],
 });
 ```
 </CodeGroup>
@@ -251,7 +251,7 @@ evaluate(
             {"sources": ["expected", "Output"]},
         )
     ],
-    scorers=[contains_scorer(source="Primary or output", value="primary")],
+    scorers=[contains_scorer(source_column="Primary or output", expected="primary")],
 )
 ```
 
@@ -288,7 +288,7 @@ await evaluate("coalesce-demo", {
       sources: ["expected", "Output"],
     }),
   ],
-  scorers: [containsScorer({ source: "Primary or output", value: "primary" })],
+  scorers: [containsScorer({ sourceColumn: "Primary or output", expected: "primary" })],
 });
 ```
 </CodeGroup>
@@ -355,7 +355,7 @@ evaluate(
             {"sources": ["Output", "expected"]},
         )
     ],
-    scorers=[count_scorer(source="Output", type="words", min_count=1)],
+    scorers=[count_scorer(source_column="Output", type="words", min_count=1)],
 )
 ```
 
@@ -387,7 +387,7 @@ await evaluate("cosine-demo", {
       sources: ["Output", "expected"],
     }),
   ],
-  scorers: [countScorer({ source: "Output", type: "words", minCount: 1 })],
+  scorers: [countScorer({ sourceColumn: "Output", type: "words", minCount: 1 })],
 });
 ```
 </CodeGroup>
@@ -435,7 +435,7 @@ evaluate(
             {"source": "Output", "query": "Extract the order number only"},
         )
     ],
-    scorers=[contains_scorer(source="Order id", value="99")],
+    scorers=[contains_scorer(source_column="Order id", expected="99")],
 )
 ```
 
@@ -469,7 +469,7 @@ await evaluate("extract-demo", {
       query: "Extract the order number only",
     }),
   ],
-  scorers: [containsScorer({ source: "Order id", value: "99" })],
+  scorers: [containsScorer({ sourceColumn: "Order id", expected: "99" })],
 });
 ```
 </CodeGroup>

--- a/sdks/evals/columns/overview.mdx
+++ b/sdks/evals/columns/overview.mdx
@@ -71,11 +71,16 @@ evaluate(
             ColumnType.PROMPT_TEMPLATE,
             {
                 "template": {"name": "summarize", "version_number": 1},
-                "prompt_template_variable_mappings": {"topic": "Input"},
+                "prompt_template_variable_mappings": {"topic": "input"},
             },
         )
     ],
-    scorers=[compare_scorer(sources=["Prompt output", "Expected"])],
+    scorers=[
+        compare_scorer(
+            source="Prompt output",
+            value_source="expected",
+        )
+    ],
 )
 ```
 
@@ -105,10 +110,15 @@ await evaluate("prompt-column-demo", {
   columns: [
     column("Prompt output", ColumnType.PROMPT_TEMPLATE, {
       template: { name: "summarize", version_number: 1 },
-      prompt_template_variable_mappings: { topic: "Input" },
+      prompt_template_variable_mappings: { topic: "input" },
     }),
   ],
-  scorers: [compareScorer({ sources: ["Prompt output", "Expected"] })],
+  scorers: [
+    compareScorer({
+      source: "Prompt output",
+      valueSource: "expected",
+    }),
+  ],
 });
 ```
 </CodeGroup>
@@ -238,7 +248,7 @@ evaluate(
         column(
             "Primary or output",
             ColumnType.COALESCE,
-            {"sources": ["Expected", "Output"]},
+            {"sources": ["expected", "Output"]},
         )
     ],
     scorers=[contains_scorer(source="Primary or output", value="primary")],
@@ -275,7 +285,7 @@ await evaluate("coalesce-demo", {
   runner: runLlm,
   columns: [
     column("Primary or output", ColumnType.COALESCE, {
-      sources: ["Expected", "Output"],
+      sources: ["expected", "Output"],
     }),
   ],
   scorers: [containsScorer({ source: "Primary or output", value: "primary" })],
@@ -342,7 +352,7 @@ evaluate(
         column(
             "Similarity",
             ColumnType.COSINE_SIMILARITY,
-            {"sources": ["Output", "Expected"]},
+            {"sources": ["Output", "expected"]},
         )
     ],
     scorers=[count_scorer(source="Output", type="words", min_count=1)],
@@ -374,7 +384,7 @@ await evaluate("cosine-demo", {
   runner: runLlm,
   columns: [
     column("Similarity", ColumnType.COSINE_SIMILARITY, {
-      sources: ["Output", "Expected"],
+      sources: ["Output", "expected"],
     }),
   ],
   scorers: [countScorer({ source: "Output", type: "words", minCount: 1 })],
@@ -487,7 +497,7 @@ column(
     ColumnType.FOR_LOOP,
     {
         "loop_type": "prompt",
-        "iterator_source": "Input",
+        "iterator_source": "input",
         "prompt_config": {
             "template": {"name": "process-item", "version_number": 1},
             "prompt_template_variable_mappings": {"item": "_iterator_item"},
@@ -503,7 +513,7 @@ import { column, ColumnType } from "promptlayer";
 
 column("Expand items", ColumnType.FOR_LOOP, {
   loop_type: "prompt",
-  iterator_source: "Input",
+  iterator_source: "input",
   prompt_config: {
     template: { name: "process-item", version_number: 1 },
     prompt_template_variable_mappings: { item: "_iterator_item" },
@@ -541,7 +551,7 @@ column(
         "end_condition_json_path": "$.done",
         "prompt_config": {
             "template": {"name": "refine", "version_number": 1},
-            "prompt_template_variable_mappings": {"draft": "Input"},
+            "prompt_template_variable_mappings": {"draft": "input"},
         },
         "variable_mappings": {},
         "return_all_outputs": False,
@@ -558,7 +568,7 @@ column("Refine until done", ColumnType.WHILE_LOOP, {
   end_condition_json_path: "$.done",
   prompt_config: {
     template: { name: "refine", version_number: 1 },
-    prompt_template_variable_mappings: { draft: "Input" },
+    prompt_template_variable_mappings: { draft: "input" },
   },
   variable_mappings: {},
   return_all_outputs: false,

--- a/sdks/evals/concurrency.mdx
+++ b/sdks/evals/concurrency.mdx
@@ -48,7 +48,7 @@ evaluate(
     "support-parallel",
     dataset=dataset,
     runner=run_llm,
-    scorers=[contains_scorer(source="Output", value_source="expected")],
+    scorers=[contains_scorer(source_column="Output", expected_column="expected")],
     max_concurrency=4,
 )
 
@@ -58,7 +58,7 @@ asyncio.run(
         "support-parallel-async",
         dataset=dataset,
         runner=run_llm_async,
-        scorers=[contains_scorer(source="Output", value_source="expected")],
+        scorers=[contains_scorer(source_column="Output", expected_column="expected")],
         max_concurrency=4,
     )
 )
@@ -88,7 +88,7 @@ await evaluate("support-parallel", {
     { input: "How do I update billing?", expected: "billing" },
   ],
   runner: runLlm,
-  scorers: [containsScorer({ source: "Output", valueSource: "expected" })],
+  scorers: [containsScorer({ sourceColumn: "Output", expectedColumn: "expected" })],
   maxConcurrency: 4,
 });
 ```

--- a/sdks/evals/concurrency.mdx
+++ b/sdks/evals/concurrency.mdx
@@ -48,7 +48,7 @@ evaluate(
     "support-parallel",
     dataset=dataset,
     runner=run_llm,
-    scorers=[contains_scorer(source="Output", value_source="Expected")],
+    scorers=[contains_scorer(source="Output", value_source="expected")],
     max_concurrency=4,
 )
 
@@ -58,7 +58,7 @@ asyncio.run(
         "support-parallel-async",
         dataset=dataset,
         runner=run_llm_async,
-        scorers=[contains_scorer(source="Output", value_source="Expected")],
+        scorers=[contains_scorer(source="Output", value_source="expected")],
         max_concurrency=4,
     )
 )
@@ -88,7 +88,7 @@ await evaluate("support-parallel", {
     { input: "How do I update billing?", expected: "billing" },
   ],
   runner: runLlm,
-  scorers: [containsScorer({ source: "Output", valueSource: "Expected" })],
+  scorers: [containsScorer({ source: "Output", valueSource: "expected" })],
   maxConcurrency: 4,
 });
 ```

--- a/sdks/evals/datasets.mdx
+++ b/sdks/evals/datasets.mdx
@@ -53,7 +53,7 @@ const dataset = [
 | `expected_trace` / `expectedTrace` | `expected_trace` (Python) / `expectedTrace` (JS) | Optional Trajectory config; only needed with Trajectory |
 | other keys | same as the key | Custom TEXT columns; sparse across rows |
 
-Extra keys become sparse TEXT columns (empty when missing). Point scorers at the same title — for example `contains_scorer(source="topic", value="math")`. Names must not collide with reserved columns (`input`, `expected`, `Output`, `Trace`, `expected_trace` / `expectedTrace`, or legacy `Input` / `Expected` / `Expected Trace`) or with [supporting column](/sdks/evals/columns/overview) titles.
+Extra keys become sparse TEXT columns (empty when missing). Point scorers at the same title — for example `contains_scorer(source_column="topic", expected="math")`. Names must not collide with reserved columns (`input`, `expected`, `Output`, `Trace`, `expected_trace` / `expectedTrace`, or legacy `Input` / `Expected` / `Expected Trace`) or with [supporting column](/sdks/evals/columns/overview) titles.
 
 ## Use a dashboard Table
 
@@ -80,7 +80,7 @@ evaluate(
     "from-dashboard",
     dataset={"table_id": "00000000-0000-0000-0000-000000000000"},
     runner=run_llm,
-    scorers=[contains_scorer(source="Output", value="reset")],
+    scorers=[contains_scorer(source_column="Output", expected="reset")],
 )
 ```
 
@@ -104,7 +104,7 @@ async function runLlm(userMessage) {
 await evaluate("from-dashboard", {
   dataset: { tableId: "00000000-0000-0000-0000-000000000000" },
   runner: runLlm,
-  scorers: [containsScorer({ source: "Output", value: "reset" })],
+  scorers: [containsScorer({ sourceColumn: "Output", expected: "reset" })],
 });
 ```
 </CodeGroup>

--- a/sdks/evals/datasets.mdx
+++ b/sdks/evals/datasets.mdx
@@ -9,17 +9,19 @@ Case fields:
 
 - `input` — required; passed to the `runner`
 - `expected` — optional; expected **output** (Contains, Compare, and similar)
-- `expected_trace` / `expectedTrace` — optional; only for [Trajectory](/sdks/evals/scorers/overview#trajectory) scorer. This is Trajectory config that describes the accepted tool scenarios.
+- `expected_trace` / `expectedTrace` — optional; only for [Trajectory](/sdks/evals/scorers/overview#trajectory). Trajectory config that describes the accepted tool scenarios
+- **any other key** — optional custom field; becomes a TEXT column with that exact title
 
 ## Inline cases
 
 <CodeGroup>
 ```python Python
 dataset = [
-    {"input": "What is 2+2?", "expected": "4"},
+    {"input": "What is 2+2?", "expected": "4", "topic": "math"},
     {
         "input": "What is the weather in Tokyo?",
         "expected": "72",
+        "topic": "weather",
         "expected_trace": {
             "accepted_scenarios": [
                 {"required_tools": ["get_weather"]}
@@ -31,10 +33,11 @@ dataset = [
 
 ```javascript JavaScript
 const dataset = [
-  { input: "What is 2+2?", expected: "4" },
+  { input: "What is 2+2?", expected: "4", topic: "math" },
   {
     input: "What is the weather in Tokyo?",
     expected: "72",
+    topic: "weather",
     expectedTrace: {
       accepted_scenarios: [{ required_tools: ["get_weather"] }],
     },
@@ -43,15 +46,18 @@ const dataset = [
 ```
 </CodeGroup>
 
-| Field | Becomes | Meaning |
+| Field | Column title | Meaning |
 | --- | --- | --- |
-| `input` | `Input` | Passed to the `runner` |
-| `expected` | `Expected` | Optional expected output |
-| `expected_trace` / `expectedTrace` | `Expected Trace` | Optional Trajectory config; only needed with Trajectory |
+| `input` | `input` | Passed to the `runner` |
+| `expected` | `expected` | Optional expected output |
+| `expected_trace` / `expectedTrace` | `expected_trace` (Python) / `expectedTrace` (JS) | Optional Trajectory config; only needed with Trajectory |
+| other keys | same as the key | Custom TEXT columns; sparse across rows |
+
+Extra keys become sparse TEXT columns (empty when missing). Point scorers at the same title — for example `contains_scorer(source="topic", value="math")`. Names must not collide with reserved columns (`input`, `expected`, `Output`, `Trace`, `expected_trace` / `expectedTrace`, or legacy `Input` / `Expected` / `Expected Trace`) or with [supporting column](/sdks/evals/columns/overview) titles.
 
 ## Use a dashboard Table
 
-Pass a Table id. The SDK reads `Input` / `Expected` / `Expected Trace` from that sheet and writes results to a **new** experiment sheet.
+Pass a Table id. The SDK reads `input` / `expected` / `expected_trace` (or `expectedTrace` in JS) plus other non-reserved TEXT columns from that sheet and writes results to a **new** experiment sheet. Legacy titles (`Input`, `Expected`, `Expected Trace`) still resolve.
 
 <CodeGroup>
 ```python Python
@@ -110,3 +116,4 @@ Optional `sheet_id` / `sheetId` picks a non-default source sheet. Omit it to use
 - Empty dataset or a case without `input`
 - Passing a Table title instead of `table_id` / `tableId`
 - Setting top-level `sheet_id` on `evaluate(...)` — that targets the experiment sheet and is rejected
+- Custom field names that collide with reserved columns or supporting column titles

--- a/sdks/evals/overview.mdx
+++ b/sdks/evals/overview.mdx
@@ -56,10 +56,10 @@ evaluate(
     runner=run_agent,
     scorers=[
         trajectory_scorer(
-            accepted_scenarios=[["get_weather"]],
+            expected=[["get_weather"]],
             mode="non_strict",
         ),
-        contains_scorer(source="Output", value="72"),
+        contains_scorer(source_column="Output", expected="72"),
     ],
     passing_score=1.0,
 )
@@ -100,10 +100,10 @@ await evaluate("weather-agent-eval", {
   runner: runAgent,
   scorers: [
     trajectoryScorer({
-      acceptedScenarios: [["get_weather"]],
+      expected: [["get_weather"]],
       mode: "non_strict",
     }),
-    containsScorer({ source: "Output", value: "72" }),
+    containsScorer({ sourceColumn: "Output", expected: "72" }),
   ],
   passingScore: 1.0,
 });

--- a/sdks/evals/overview.mdx
+++ b/sdks/evals/overview.mdx
@@ -8,7 +8,7 @@ icon: "book"
 In addition to being able to evaluate your agent via our dashboard, you can create an evaluation directly in code with our SDK.
 
 Each eval has four parts:
-- **Dataset** — user messages (and optional expected output / expected tool trajectory)
+- **Dataset** — user messages (and optional expected output, expected tool trajectory, or custom fields)
 - **Runner** — your agent harness (OpenAI Agents, Claude, LangChain, or any callable that takes `input` and returns a final value)
 - **Columns** - optional steps to manipulate your dataset or agent trace
 - **Scorers** — scorecard checks such as Trajectory and Contains

--- a/sdks/evals/quickstart.mdx
+++ b/sdks/evals/quickstart.mdx
@@ -98,7 +98,7 @@ Follow current PromptLayer SDK evals docs:
   - Anything else / custom agent: wrap **existing** handlers with PromptLayer `traceTool` (JS: `pl.traceTool("name", fn)`; Python: `@pl.traceTool(name="name")`).
 - For custom / raw OpenAI client runners: keep the repo’s existing client. Prefer the official OpenAI client over `pl.openai.OpenAI()` / `new pl.OpenAI()` unless the repo already depends on the PromptLayer provider wrapper.
 - Dataset cases use `input`, plus optional `expected` (expected output). Add `expected_trace` / `expectedTrace` only when using Trajectory. Extra keys become custom TEXT columns with that exact title (no reserved names: `input`, `expected`, `Output`, `Trace`, `expected_trace` / `expectedTrace`, or legacy `Input` / `Expected` / `Expected Trace`).
-- Builtin sheet columns are `input`, `expected`, `expected_trace` / `expectedTrace`, `Output`, and `Trace`. Compare defaults to `source="Output"` and `value_source` / `valueSource` `"expected"`; Trajectory column mode uses `value_source` / `valueSource` (not `expected_source`).
+- Builtin sheet columns are `input`, `expected`, `expected_trace` / `expectedTrace`, `Output`, and `Trace`. Scorers take `source_column` / `sourceColumn`. Compare / Contains / Trajectory use `expected` (literal or inline scenarios) or `expected_column` / `expectedColumn` (column-backed).
 - Prefer scorers that match the purpose: Trajectory for tool path, Contains / Compare / LLM assertion for the final answer.
 - Results must land in PromptLayer Tables via the SDK eval runner.
 
@@ -204,10 +204,10 @@ evaluate(
     runner=run_agent,
     scorers=[
         trajectory_scorer(
-            accepted_scenarios=[["get_weather"]],
+            expected=[["get_weather"]],
             mode="non_strict",
         ),
-        contains_scorer(source="Output", value="72"),
+        contains_scorer(source_column="Output", expected="72"),
     ],
     passing_score=1.0,
 )
@@ -248,10 +248,10 @@ await evaluate("weather-agent-eval", {
   runner: runAgent,
   scorers: [
     trajectoryScorer({
-      acceptedScenarios: [["get_weather"]],
+      expected: [["get_weather"]],
       mode: "non_strict",
     }),
-    containsScorer({ source: "Output", value: "72" }),
+    containsScorer({ sourceColumn: "Output", expected: "72" }),
   ],
   passingScore: 1.0,
 });
@@ -319,10 +319,10 @@ asyncio.run(
         runner=run_agent,
         scorers=[
             trajectory_scorer(
-                accepted_scenarios=[["Bash"]],
+                expected=[["Bash"]],
                 mode="non_strict",
             ),
-            contains_scorer(source="Output", value="hello"),
+            contains_scorer(source_column="Output", expected="hello"),
         ],
         passing_score=1.0,
     )
@@ -371,10 +371,10 @@ await evaluate("claude-agent-eval", {
   runner: runAgent,
   scorers: [
     trajectoryScorer({
-      acceptedScenarios: [["Bash"]],
+      expected: [["Bash"]],
       mode: "non_strict",
     }),
-    containsScorer({ source: "Output", value: "hello" }),
+    containsScorer({ sourceColumn: "Output", expected: "hello" }),
   ],
   passingScore: 1.0,
 });
@@ -426,10 +426,10 @@ await evaluate("vercel-weather-eval", {
   runner: runAgent,
   scorers: [
     trajectoryScorer({
-      acceptedScenarios: [["get_weather"]],
+      expected: [["get_weather"]],
       mode: "non_strict",
     }),
-    containsScorer({ source: "Output", value: "72" }),
+    containsScorer({ sourceColumn: "Output", expected: "72" }),
   ],
   passingScore: 1.0,
 });
@@ -513,10 +513,10 @@ evaluate(
     runner=run_agent,
     scorers=[
         trajectory_scorer(
-            accepted_scenarios=[["get_weather"]],
+            expected=[["get_weather"]],
             mode="non_strict",
         ),
-        contains_scorer(source="Output", value="72"),
+        contains_scorer(source_column="Output", expected="72"),
     ],
     passing_score=1.0,
 )
@@ -592,10 +592,10 @@ await evaluate("langchain-weather-eval", {
   runner: runAgent,
   scorers: [
     trajectoryScorer({
-      acceptedScenarios: [["get_weather"]],
+      expected: [["get_weather"]],
       mode: "non_strict",
     }),
-    containsScorer({ source: "Output", value: "72" }),
+    containsScorer({ sourceColumn: "Output", expected: "72" }),
   ],
   passingScore: 1.0,
 });
@@ -653,10 +653,10 @@ evaluate(
     runner=run_agent,
     scorers=[
         trajectory_scorer(
-            accepted_scenarios=[["get_weather"]],
+            expected=[["get_weather"]],
             mode="non_strict",
         ),
-        contains_scorer(source="Output", value="72"),
+        contains_scorer(source_column="Output", expected="72"),
     ],
     passing_score=1.0,
 )
@@ -686,10 +686,10 @@ evaluate(
     runner=run_openclaw_agent,
     scorers=[
         trajectory_scorer(
-            accepted_scenarios=[["get_weather"]],  # your real tool names
+            expected=[["get_weather"]],  # your real tool names
             mode="non_strict",
         ),
-        contains_scorer(source="Output", value="72"),
+        contains_scorer(source_column="Output", expected="72"),
     ],
     passing_score=0.8,
 )

--- a/sdks/evals/quickstart.mdx
+++ b/sdks/evals/quickstart.mdx
@@ -97,7 +97,8 @@ Follow current PromptLayer SDK evals docs:
   - LiteLLM (Python, if used): `PromptLayer(enable_tracing=True)`, optional `litellm.success_callback = ["promptlayer"]`, and `traceTool` on **existing** tool handlers.
   - Anything else / custom agent: wrap **existing** handlers with PromptLayer `traceTool` (JS: `pl.traceTool("name", fn)`; Python: `@pl.traceTool(name="name")`).
 - For custom / raw OpenAI client runners: keep the repo’s existing client. Prefer the official OpenAI client over `pl.openai.OpenAI()` / `new pl.OpenAI()` unless the repo already depends on the PromptLayer provider wrapper.
-- Dataset cases use `input`, plus optional `expected` (expected output). Add `expected_trace` / `expectedTrace` only when using Trajectory.
+- Dataset cases use `input`, plus optional `expected` (expected output). Add `expected_trace` / `expectedTrace` only when using Trajectory. Extra keys become custom TEXT columns with that exact title (no reserved names: `input`, `expected`, `Output`, `Trace`, `expected_trace` / `expectedTrace`, or legacy `Input` / `Expected` / `Expected Trace`).
+- Builtin sheet columns are `input`, `expected`, `expected_trace` / `expectedTrace`, `Output`, and `Trace`. Compare defaults to `source="Output"` and `value_source` / `valueSource` `"expected"`; Trajectory column mode uses `value_source` / `valueSource` (not `expected_source`).
 - Prefer scorers that match the purpose: Trajectory for tool path, Contains / Compare / LLM assertion for the final answer.
 - Results must land in PromptLayer Tables via the SDK eval runner.
 
@@ -734,12 +735,12 @@ Evaluation Results:
   ↗ https://dashboard.promptlayer.com/workspace/.../smart-tables/...
 ```
 
-Each run also writes a Table experiment sheet with `Input`, `Output`, and (when you score traces) a `Trace` group with price and latency. The score panel shows each scorer — here Trajectory on Trace and Contains on Output — plus the overall pass rate.
+Each run also writes a Table experiment sheet with `input`, `Output`, and (when you score traces) a `Trace` group with price and latency. The score panel shows each scorer — here Trajectory on Trace and Contains on Output — plus the overall pass rate.
 
 <Frame>
   <img
     src="/images/evals/weather-agent-eval-results.png"
-    alt="weather-agent-eval experiment sheet showing Input, Output, Trace, and 100% pass for Trajectory and Contains"
+    alt="weather-agent-eval experiment sheet showing input, Output, Trace, and 100% pass for Trajectory and Contains"
   />
 </Frame>
 

--- a/sdks/evals/results-and-failures.mdx
+++ b/sdks/evals/results-and-failures.mdx
@@ -40,7 +40,7 @@ try:
         "support-gate",
         dataset=[{"input": "How do I reset my password?"}],
         runner=run_llm,
-        scorers=[contains_scorer(source="Output", value="reset")],
+        scorers=[contains_scorer(source_column="Output", expected="reset")],
         passing_score=0.8,
         include_failure_examples=True,
     )
@@ -71,7 +71,7 @@ try {
   const result = await evaluate("support-gate", {
     dataset: [{ input: "How do I reset my password?" }],
     runner: runLlm,
-    scorers: [containsScorer({ source: "Output", value: "reset" })],
+    scorers: [containsScorer({ sourceColumn: "Output", expected: "reset" })],
     passingScore: 0.8,
     includeFailureExamples: true,
   });

--- a/sdks/evals/scorers/overview.mdx
+++ b/sdks/evals/scorers/overview.mdx
@@ -13,7 +13,7 @@ Thresholds, weights, and the overall score work the same as [Scorecards](/featur
 
 | Scorer | Python | JavaScript | Checks |
 | --- | --- | --- | --- |
-| [Compare](#compare) | `compare_scorer` | `compareScorer` | Two columns match (default `Output` vs `Expected`) |
+| [Compare](#compare) | `compare_scorer` | `compareScorer` | Two columns match (default `Output` vs `expected`) |
 | [Contains](#contains) | `contains_scorer` | `containsScorer` | A column contains a literal or another column's value |
 | [Regex](#regex) | `regex_scorer` | `regexScorer` | A column matches a regular expression |
 | [Count](#count) | `count_scorer` | `countScorer` | Character / word / sentence / paragraph count within bounds |
@@ -155,7 +155,13 @@ Each helper below maps to a scorecard check type in [Column Types](/features/tab
 
 ### Compare
 
-Compare two columns. By default that is `Output` vs `Expected` as strings. Pass exactly two column titles in `sources`. Behavior matches the Compare type in [Column Types](/features/tables/column-types).
+Compare two columns. By default that is `Output` vs `expected` as strings. Pass the left column as `source` and the right as `value_source` / `valueSource`. Behavior matches the Compare type in [Column Types](/features/tables/column-types).
+
+| Key | Required | Default |
+| --- | --- | --- |
+| `source` | no | `"Output"` |
+| `value_source` / `valueSource` | no | `"expected"` |
+| `comparison_type` / `comparisonType` | no | `"STRING"` |
 
 Set how they compare with `comparison_type` / `comparisonType`:
 
@@ -194,7 +200,8 @@ evaluate(
     scorers=[
         compare_scorer(
             "Exact match",
-            sources=["Output", "Expected"],
+            source="Output",
+            value_source="expected",
             comparison_type="STRING",
         )
     ],
@@ -224,7 +231,8 @@ await evaluate("compare-demo", {
   scorers: [
     compareScorer({
       title: "Exact match",
-      sources: ["Output", "Expected"],
+      source: "Output",
+      valueSource: "expected",
       comparisonType: "STRING",
     }),
   ],
@@ -586,13 +594,13 @@ await evaluate("llm-assert-demo", {
 
 Scores `Tool: <name>` spans from the imported `Trace` against accepted scenarios. Any `runner` works if those spans exist — emit them with a framework helper or [`traceTool`](/running-requests/traces#tracing-tools) (see [Runner](/sdks/evals/agent-tracing)), or copy a harness from the [Quickstart](/sdks/evals/quickstart).
 
-Pass **exactly one of** inline `accepted_scenarios` / `acceptedScenarios`, or `expected_source` / `expectedSource` (usually `"Expected Trace"`).
+Pass **exactly one of** inline `accepted_scenarios` / `acceptedScenarios`, or `value_source` / `valueSource` (usually `"expected_trace"` / `"expectedTrace"`).
 
 | Key | Required | Default |
 | --- | --- | --- |
-| `trace_source` / `traceSource` | yes | `"Trace"` |
+| `source` | no | `"Trace"` |
 | `accepted_scenarios` / `acceptedScenarios` | one of | list of non-empty tool-name lists |
-| `expected_source` / `expectedSource` | one of | column title |
+| `value_source` / `valueSource` | one of | column title |
 | `mode` | no | `"strict"` |
 
 | Mode | Behavior |
@@ -666,7 +674,7 @@ await evaluate("trajectory-demo", {
 ```
 </CodeGroup>
 
-Or read scenarios from an Expected Trace column. Cell JSON:
+Or read scenarios from the `expected_trace` / `expectedTrace` column. Cell JSON:
 
 ```json
 {
@@ -679,14 +687,14 @@ Or read scenarios from an Expected Trace column. Cell JSON:
 <CodeGroup>
 ```python Python
 trajectory_scorer(
-    expected_source="Expected Trace",
+    value_source="expected_trace",
     mode="non_strict",
 )
 ```
 
 ```javascript JavaScript
 trajectoryScorer({
-  expectedSource: "Expected Trace",
+  valueSource: "expectedTrace",
   mode: "non_strict",
 })
 ```
@@ -704,9 +712,10 @@ Parameter names map to columns:
 
 | Param | Column |
 | --- | --- |
-| `input` | `Input` |
+| `input` | `input` |
 | `output` | `Output` |
-| `expected` | `Expected` |
+| `expected` | `expected` |
+| `expected_trace` | `expected_trace` (Python) |
 | `trace` | `Trace` |
 
 Any other param name is looked up as a column title of the same name. Return a number (or `{"score": x}`, which is normalized to `x`).
@@ -829,7 +838,7 @@ evaluate(
         code_execution_column(
             "exact",
             code=(
-                'return 1 if str(data.get("Expected", "")).lower() '
+                'return 1 if str(data.get("expected", "")).lower() '
                 'in str(data.get("Output", "")).lower() else 0'
             ),
         )
@@ -867,7 +876,7 @@ await evaluate("code-scorer-demo", {
   runner: runLlm,
   scorers: [
     codeExecutionColumn("exact", {
-      code: 'return String(data["Output"] || "").toLowerCase().includes(String(data["Expected"] || "").toLowerCase()) ? 1 : 0;',
+      code: 'return String(data["Output"] || "").toLowerCase().includes(String(data["expected"] || "").toLowerCase()) ? 1 : 0;',
     }),
   ],
 });

--- a/sdks/evals/scorers/overview.mdx
+++ b/sdks/evals/scorers/overview.mdx
@@ -13,7 +13,7 @@ Thresholds, weights, and the overall score work the same as [Scorecards](/featur
 
 | Scorer | Python | JavaScript | Checks |
 | --- | --- | --- | --- |
-| [Compare](#compare) | `compare_scorer` | `compareScorer` | Two columns match (default `Output` vs `expected`) |
+| [Compare](#compare) | `compare_scorer` | `compareScorer` | A column matches a literal or another column (default `Output` vs `expected`) |
 | [Contains](#contains) | `contains_scorer` | `containsScorer` | A column contains a literal or another column's value |
 | [Regex](#regex) | `regex_scorer` | `regexScorer` | A column matches a regular expression |
 | [Count](#count) | `count_scorer` | `countScorer` | Character / word / sentence / paragraph count within bounds |
@@ -80,12 +80,12 @@ evaluate(
     scorers=[
         contains_scorer(
             "Has apology",
-            source="Output",
-            value="sorry",
+            source_column="Output",
+            expected="sorry",
             weight=1.0,
         ),
         trajectory_scorer(
-            accepted_scenarios=[["lookup_user", "send_reset"]],
+            expected=[["lookup_user", "send_reset"]],
             weight=2.5,
             required=True,
             pass_threshold=0.9,
@@ -134,12 +134,12 @@ await evaluate("support-bot", {
   scorers: [
     containsScorer({
       title: "Has apology",
-      source: "Output",
-      value: "sorry",
+      sourceColumn: "Output",
+      expected: "sorry",
       weight: 1.0,
     }),
     trajectoryScorer({
-      acceptedScenarios: [["lookup_user", "send_reset"]],
+      expected: [["lookup_user", "send_reset"]],
       weight: 2.5,
       required: true,
       passThreshold: 0.9,
@@ -155,12 +155,13 @@ Each helper below maps to a scorecard check type in [Column Types](/features/tab
 
 ### Compare
 
-Compare two columns. By default that is `Output` vs `expected` as strings. Pass the left column as `source` and the right as `value_source` / `valueSource`. Behavior matches the Compare type in [Column Types](/features/tables/column-types).
+Compare a column to a literal or another column. By default that is `Output` vs the `expected` column as strings. Pass the left column as `source_column` / `sourceColumn`, then exactly one of `expected` (literal) or `expected_column` / `expectedColumn`. If you omit both expected options, the SDK uses column `expected`. Behavior matches the Compare type in [Column Types](/features/tables/column-types).
 
 | Key | Required | Default |
 | --- | --- | --- |
-| `source` | no | `"Output"` |
-| `value_source` / `valueSource` | no | `"expected"` |
+| `source_column` / `sourceColumn` | no | `"Output"` |
+| `expected` | one of | literal value |
+| `expected_column` / `expectedColumn` | one of | `"expected"` when both omitted |
 | `comparison_type` / `comparisonType` | no | `"STRING"` |
 
 Set how they compare with `comparison_type` / `comparisonType`:
@@ -200,8 +201,8 @@ evaluate(
     scorers=[
         compare_scorer(
             "Exact match",
-            source="Output",
-            value_source="expected",
+            source_column="Output",
+            expected_column="expected",
             comparison_type="STRING",
         )
     ],
@@ -231,8 +232,8 @@ await evaluate("compare-demo", {
   scorers: [
     compareScorer({
       title: "Exact match",
-      source: "Output",
-      valueSource: "expected",
+      sourceColumn: "Output",
+      expectedColumn: "expected",
       comparisonType: "STRING",
     }),
   ],
@@ -242,13 +243,13 @@ await evaluate("compare-demo", {
 
 ### Contains
 
-Check whether a column contains a literal or another column's value. Pass exactly one of `value` or `value_source` / `valueSource`.
+Check whether a column contains a literal or another column's value. Pass exactly one of `expected` or `expected_column` / `expectedColumn`.
 
 | Key | Required | Default |
 | --- | --- | --- |
-| `source` | yes | `"Output"` |
-| `value` | one of | literal substring |
-| `value_source` / `valueSource` | one of | column title |
+| `source_column` / `sourceColumn` | no | `"Output"` |
+| `expected` | one of | literal substring |
+| `expected_column` / `expectedColumn` | one of | column title |
 
 <CodeGroup>
 ```python Python
@@ -274,7 +275,7 @@ evaluate(
     "contains-demo",
     dataset=[{"input": "I cannot log in to my account."}],
     runner=run_llm,
-    scorers=[contains_scorer(source="Output", value="sorry")],
+    scorers=[contains_scorer(source_column="Output", expected="sorry")],
 )
 ```
 
@@ -301,7 +302,7 @@ async function runLlm(userMessage) {
 await evaluate("contains-demo", {
   dataset: [{ input: "I cannot log in to my account." }],
   runner: runLlm,
-  scorers: [containsScorer({ source: "Output", value: "sorry" })],
+  scorers: [containsScorer({ sourceColumn: "Output", expected: "sorry" })],
 });
 ```
 </CodeGroup>
@@ -312,7 +313,7 @@ Match a column against a regular expression.
 
 | Key | Required | Default |
 | --- | --- | --- |
-| `source` | yes | `"Output"` |
+| `source_column` / `sourceColumn` | no | `"Output"` |
 | `regex_pattern` / `regexPattern` | yes | — |
 
 <CodeGroup>
@@ -342,7 +343,7 @@ evaluate(
     "regex-demo",
     dataset=[{"input": "What is the order id for my headphones?"}],
     runner=run_llm,
-    scorers=[regex_scorer(source="Output", regex_pattern=r"order-\d+")],
+    scorers=[regex_scorer(source_column="Output", regex_pattern=r"order-\d+")],
 )
 ```
 
@@ -370,7 +371,7 @@ async function runLlm(userMessage) {
 await evaluate("regex-demo", {
   dataset: [{ input: "What is the order id for my headphones?" }],
   runner: runLlm,
-  scorers: [regexScorer({ source: "Output", regexPattern: "order-\\d+" })],
+  scorers: [regexScorer({ sourceColumn: "Output", regexPattern: "order-\\d+" })],
 });
 ```
 </CodeGroup>
@@ -381,7 +382,7 @@ Score by character, word, sentence, or paragraph count bounds. Require at least 
 
 | Key | Required | Default |
 | --- | --- | --- |
-| `source` | yes | `"Output"` |
+| `source_column` / `sourceColumn` | no | `"Output"` |
 | `type` | no | `"chars"` |
 | `min_count` / `minCount` | one of min/max | — |
 | `max_count` / `maxCount` | one of min/max | — |
@@ -410,7 +411,7 @@ evaluate(
     "count-demo",
     dataset=[{"input": "How do I reset my password?"}],
     runner=run_llm,
-    scorers=[count_scorer(source="Output", type="words", min_count=1, max_count=5)],
+    scorers=[count_scorer(source_column="Output", type="words", min_count=1, max_count=5)],
 )
 ```
 
@@ -438,7 +439,7 @@ await evaluate("count-demo", {
   dataset: [{ input: "How do I reset my password?" }],
   runner: runLlm,
   scorers: [
-    countScorer({ source: "Output", type: "words", minCount: 1, maxCount: 5 }),
+    countScorer({ sourceColumn: "Output", type: "words", minCount: 1, maxCount: 5 }),
   ],
 });
 ```
@@ -450,7 +451,7 @@ Validate a column as object, number, or SQL. There is no `json` / `boolean` / `s
 
 | Key | Required | Default | Allowed |
 | --- | --- | --- | --- |
-| `source` | yes | `"Output"` | column title |
+| `source_column` / `sourceColumn` | no | `"Output"` | column title |
 | `type` | yes | `"object"` | `object` \| `number` \| `sql` |
 
 <CodeGroup>
@@ -480,7 +481,7 @@ evaluate(
     "assert-valid-demo",
     dataset=[{"input": "Create a support ticket for a billing issue."}],
     runner=run_llm,
-    scorers=[assert_valid_scorer(source="Output", type="object")],
+    scorers=[assert_valid_scorer(source_column="Output", type="object")],
 )
 ```
 
@@ -508,7 +509,7 @@ async function runLlm(userMessage) {
 await evaluate("assert-valid-demo", {
   dataset: [{ input: "Create a support ticket for a billing issue." }],
   runner: runLlm,
-  scorers: [assertValidScorer({ source: "Output", type: "object" })],
+  scorers: [assertValidScorer({ sourceColumn: "Output", type: "object" })],
 });
 ```
 </CodeGroup>
@@ -519,7 +520,7 @@ Score a column with an LLM judge prompt. Pass exactly one of `prompt` or `prompt
 
 | Key | Required | Default |
 | --- | --- | --- |
-| `source` | yes | `"Output"` |
+| `source_column` / `sourceColumn` | no | `"Output"` |
 | `prompt` | one of | literal prompt text |
 | `prompt_source` / `promptSource` | one of | column title |
 | `variable_mappings` / `variableMappings` | no | Prompt variable → column title |
@@ -550,7 +551,7 @@ evaluate(
     runner=run_llm,
     scorers=[
         llm_assertion_scorer(
-            source="Output",
+            source_column="Output",
             prompt="Is this factually reasonable? Reply yes or no.",
         )
     ],
@@ -582,7 +583,7 @@ await evaluate("llm-assert-demo", {
   runner: runLlm,
   scorers: [
     llmAssertionScorer({
-      source: "Output",
+      sourceColumn: "Output",
       prompt: "Is this factually reasonable? Reply yes or no.",
     }),
   ],
@@ -594,13 +595,13 @@ await evaluate("llm-assert-demo", {
 
 Scores `Tool: <name>` spans from the imported `Trace` against accepted scenarios. Any `runner` works if those spans exist — emit them with a framework helper or [`traceTool`](/running-requests/traces#tracing-tools) (see [Runner](/sdks/evals/agent-tracing)), or copy a harness from the [Quickstart](/sdks/evals/quickstart).
 
-Pass **exactly one of** inline `accepted_scenarios` / `acceptedScenarios`, or `value_source` / `valueSource` (usually `"expected_trace"` / `"expectedTrace"`).
+Pass **exactly one of** inline `expected` (list of tool-name lists), or `expected_column` / `expectedColumn` (usually `"expected_trace"` / `"expectedTrace"`).
 
 | Key | Required | Default |
 | --- | --- | --- |
-| `source` | no | `"Trace"` |
-| `accepted_scenarios` / `acceptedScenarios` | one of | list of non-empty tool-name lists |
-| `value_source` / `valueSource` | one of | column title |
+| `source_column` / `sourceColumn` | no | `"Trace"` |
+| `expected` | one of | list of non-empty tool-name lists |
+| `expected_column` / `expectedColumn` | one of | column title |
 | `mode` | no | `"strict"` |
 
 | Mode | Behavior |
@@ -608,7 +609,7 @@ Pass **exactly one of** inline `accepted_scenarios` / `acceptedScenarios`, or `v
 | `strict` (default) | Observed tools must equal the scenario exactly |
 | `non_strict` | Required tools appear in order as a subsequence |
 
-Inline `accepted_scenarios`:
+Inline `expected`:
 
 <CodeGroup>
 ```python Python
@@ -635,8 +636,8 @@ evaluate(
     dataset=[{"input": "What is the weather in Tokyo?"}],
     runner=lambda message: str(Runner.run_sync(agent, message).final_output),
     scorers=[
-        trajectory_scorer(accepted_scenarios=[["get_weather"]], mode="non_strict"),
-        contains_scorer(source="Output", value="72"),
+        trajectory_scorer(expected=[["get_weather"]], mode="non_strict"),
+        contains_scorer(source_column="Output", expected="72"),
     ],
 )
 ```
@@ -667,8 +668,8 @@ await evaluate("trajectory-demo", {
   dataset: [{ input: "What is the weather in Tokyo?" }],
   runner: async (userMessage) => String((await run(agent, userMessage)).finalOutput),
   scorers: [
-    trajectoryScorer({ acceptedScenarios: [["get_weather"]], mode: "non_strict" }),
-    containsScorer({ source: "Output", value: "72" }),
+    trajectoryScorer({ expected: [["get_weather"]], mode: "non_strict" }),
+    containsScorer({ sourceColumn: "Output", expected: "72" }),
   ],
 });
 ```
@@ -687,14 +688,14 @@ Or read scenarios from the `expected_trace` / `expectedTrace` column. Cell JSON:
 <CodeGroup>
 ```python Python
 trajectory_scorer(
-    value_source="expected_trace",
+    expected_column="expected_trace",
     mode="non_strict",
 )
 ```
 
 ```javascript JavaScript
 trajectoryScorer({
-  valueSource: "expectedTrace",
+  expectedColumn: "expectedTrace",
   mode: "non_strict",
 })
 ```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Reflects SDK changes from:

- [prompt-layer-library#337](https://github.com/MagnivOrg/prompt-layer-library/pull/337) / [prompt-layer-js#191](https://github.com/MagnivOrg/prompt-layer-js/pull/191) — consistent dataset column titles and custom fields
- [prompt-layer-library#338](https://github.com/MagnivOrg/prompt-layer-library/pull/338) / [prompt-layer-js#192](https://github.com/MagnivOrg/prompt-layer-js/pull/192) — unified scorer parameter names

## Changes

### Dataset / columns
- Builtin sheet columns: `input`, `expected`, `expected_trace` (Python) / `expectedTrace` (JS)
- Custom case fields as sparse TEXT columns, with reserved-name rules
- Legacy dashboard titles still resolve

### Scorers
- `source` → `source_column` / `sourceColumn` across typed scorers
- Contains / Compare / Trajectory: `expected` (literal or inline scenarios) or `expected_column` / `expectedColumn`
- Trajectory: `accepted_scenarios` / `acceptedScenarios` → `expected`
- Examples and option tables updated across evals docs

## Touched pages

- `sdks/evals/datasets.mdx`
- `sdks/evals/building-an-eval.mdx`
- `sdks/evals/overview.mdx`
- `sdks/evals/quickstart.mdx`
- `sdks/evals/scorers/overview.mdx`
- `sdks/evals/columns/overview.mdx`
- `sdks/evals/concurrency.mdx`
- `sdks/evals/results-and-failures.mdx`
- `sdks/evals/agent-tracing.mdx`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019faaf3-3782-768e-b57b-e738d7604614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019faaf3-3782-768e-b57b-e738d7604614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

