### PR TITLE
docs: update provider SDK auto-instrumentation coverage

### DIFF
--- a/features/observability/traces/auto-instrumentation/anthropic.mdx
+++ b/features/observability/traces/auto-instrumentation/anthropic.mdx
@@ -12,15 +12,18 @@ This guide covers the Anthropic model SDK. If you use the Claude Agent SDK or Cl
 
 ## Supported APIs
 
-| Anthropic API | Python | JavaScript |
+| API surface | Python | JavaScript |
 | --- | --- | --- |
-| Messages (`messages.create`) | Sync and async | Supported |
-| Messages streaming | `messages.create(..., stream=True)` and `messages.stream()`; sync and async | `messages.create({ stream: true })` |
-| Structured message parsing (`messages.parse`) | Sync and async | Not supported |
-| Beta Messages | Not included in the documented Python surface | Create and streaming |
+| Messages (`messages.create`) | Supported (sync and async) | Supported |
+| Messages streaming | Supported (`messages.create(..., stream=True)` and `messages.stream()`; sync and async) | Supported (`messages.create({ stream: true })`) |
+| Structured message parsing (`messages.parse`) | Supported (sync and async) | Not supported |
+| Beta Messages | Not documented | Supported |
+| Beta Messages streaming | Not documented | Supported |
 | Anthropic Vertex | Supported | Supported |
 
-Anthropic Bedrock is not included in JavaScript provider auto-instrumentation. Other Anthropic SDK calls continue to work normally, but unsupported surfaces do not automatically create PromptLayer traces or request logs.
+`Not documented` means the surface is outside the verified coverage for that language.
+
+The Anthropic Bedrock client is not included in this provider integration. To trace direct Boto3 or AWS SDK v3 Bedrock Runtime calls, follow the [AWS Bedrock guide](/features/observability/traces/auto-instrumentation/bedrock). Other Anthropic SDK calls continue to work normally, but unsupported surfaces do not automatically create PromptLayer traces or request logs.
 
 ## Prerequisites
 
@@ -35,7 +38,7 @@ export PROMPTLAYER_API_KEY="pl_..."
 export ANTHROPIC_API_KEY="sk-ant-..."
 ```
 
-PromptLayer strongly recommends setting the language-specific [content-capture value](/features/observability/traces/auto-instrumentation/overview#capture-prompts-and-responses) so request inspection, search, analytics, and debugging can use prompts, responses, and tool content.
+PromptLayer captures supported message content by default. Review the [content-capture behavior and opt-out values](/features/observability/traces/auto-instrumentation/overview#capture-prompts-and-responses) before sending provider requests.
 
 ## Python
 

--- a/features/observability/traces/auto-instrumentation/bedrock.mdx
+++ b/features/observability/traces/auto-instrumentation/bedrock.mdx
@@ -1,35 +1,35 @@
 ---
 title: "AWS Bedrock"
-description: "Automatically trace supported direct Amazon Bedrock Runtime calls made with Boto3."
+description: "Automatically trace supported direct Amazon Bedrock Runtime calls made with Boto3 or AWS SDK v3."
 icon: "aws"
 ---
 
-PromptLayer can auto-instrument Boto3 calls to Amazon Bedrock Runtime and export supported operations as OpenTelemetry spans. Each supported direct Bedrock call appears in PromptLayer as both a trace span and an associated request log without replacing the Boto3 client.
+PromptLayer can auto-instrument Amazon Bedrock Runtime calls made with Boto3 or AWS SDK v3 and export supported operations as OpenTelemetry spans. Each supported direct Bedrock call appears in PromptLayer as both a trace span and an associated request log without replacing the native AWS client.
 
 <Note>
-This Python integration covers direct Boto3 `bedrock-runtime` calls. It does not instrument `aioboto3`, Anthropic's Bedrock client, or the AWS SDK for JavaScript.
+This integration covers direct Boto3 `bedrock-runtime` calls in Python and `@aws-sdk/client-bedrock-runtime` calls in JavaScript. It does not instrument `aioboto3` or the separate Anthropic Bedrock client.
 </Note>
 
 ## Supported APIs
 
-| Boto3 Bedrock Runtime method | Python |
-| --- | --- |
-| Converse (`converse`) | Supported |
-| Converse streaming (`converse_stream`) | Supported |
-| InvokeModel (`invoke_model`) | Supported |
-| InvokeModel streaming (`invoke_model_with_response_stream`) | Supported |
+| API surface | Python | JavaScript |
+| --- | --- | --- |
+| Converse | Supported (`client.converse(...)`) | Supported (`ConverseCommand`) |
+| Converse streaming | Supported (`client.converse_stream(...)`) | Not supported |
+| InvokeModel | Supported (`client.invoke_model(...)`) | Not supported |
+| InvokeModel streaming | Supported (`client.invoke_model_with_response_stream(...)`) | Not supported |
 
-Only the Bedrock Runtime operations in this table receive Bedrock-specific PromptLayer request log enrichment. For streaming operations, consume or close the response stream before flushing so the span can finish.
+Only the language-specific surfaces in this table receive Bedrock-specific PromptLayer request log enrichment. In Python, consume or close a streaming response before flushing so its span can finish.
 
 <Warning>
-Bedrock auto-instrumentation uses the OpenTelemetry Botocore instrumentor. Enabling it also traces other Botocore service calls made by the same process, although Bedrock-specific request log enrichment applies only to the supported `bedrock-runtime` operations.
+Bedrock auto-instrumentation uses the general OpenTelemetry Botocore or AWS SDK instrumentor. Enabling it can also trace other AWS SDK service calls made by the same process, although Bedrock-specific request log enrichment applies only to the supported Bedrock Runtime operations.
 </Warning>
 
 ## Prerequisites
 
 - A [PromptLayer API key](/quickstart#prerequisites) for the workspace that should receive the traces
 - AWS credentials, a region, and access to the Bedrock model or inference profile your application calls
-- Python 3.10 or later
+- Python 3.10 or later for Python, or Node.js 20 or later for JavaScript
 
 Export the PromptLayer API key before the application starts. The example below also uses `AWS_REGION` and `AWS_BEDROCK_MODEL` as application configuration:
 
@@ -37,10 +37,9 @@ Export the PromptLayer API key before the application starts. The example below 
 export PROMPTLAYER_API_KEY="pl_..."
 export AWS_REGION="us-east-1"
 export AWS_BEDROCK_MODEL="your-model-or-inference-profile-id"
-export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT="span_only"
 ```
 
-PromptLayer strongly recommends enabling content capture when your data policies allow it so request inspection, search, analytics, and debugging can use Bedrock messages and tool content.
+PromptLayer captures supported Bedrock message content by default. Review [Capture Prompts and Responses](#capture-prompts-and-responses) before sending provider requests.
 
 ## Python
 
@@ -85,9 +84,9 @@ finally:
     tracer_provider.force_flush()
 ```
 
-The canonical selector is `bedrock`. The `amazon.bedrock` and `aws.bedrock` aliases select the same Botocore instrumentor.
+The canonical selector is `bedrock`. Python also accepts `amazon.bedrock` and `aws.bedrock` as aliases for the same Botocore instrumentor.
 
-<Accordion title="Use an existing PromptLayer client">
+<Accordion title="Use an existing Python PromptLayer client">
 If your application already creates a PromptLayer client, select Bedrock when enabling tracing:
 
 ```python
@@ -104,33 +103,103 @@ client = boto3.client("bedrock-runtime", region_name="us-east-1")
 Omit `tracing_providers` to instrument every supported provider SDK that is installed.
 </Accordion>
 
+## JavaScript
+
+### 1. Install the SDKs
+
+```bash
+npm install promptlayer @aws-sdk/client-bedrock-runtime
+```
+
+### 2. Preload PromptLayer instrumentation
+
+The preload must run before the application imports the AWS SDK client:
+
+```bash
+node --import promptlayer/register app.mjs
+```
+
+### 3. Use the AWS SDK normally
+
+```javascript
+import {
+  BedrockRuntimeClient,
+  ConverseCommand,
+} from "@aws-sdk/client-bedrock-runtime";
+import { shutdownTracing } from "promptlayer";
+
+const client = new BedrockRuntimeClient({
+  region: process.env.AWS_REGION,
+});
+
+try {
+  const response = await client.send(
+    new ConverseCommand({
+      modelId: process.env.AWS_BEDROCK_MODEL,
+      messages: [
+        {
+          role: "user",
+          content: [
+            { text: "Explain distributed tracing in one sentence." },
+          ],
+        },
+      ],
+      inferenceConfig: { maxTokens: 128 },
+    }),
+  );
+  console.log(
+    response.output?.message?.content
+      ?.map((block) => block.text ?? "")
+      .join(""),
+  );
+} finally {
+  client.destroy();
+  await shutdownTracing();
+}
+```
+
+The preload instruments every supported provider. To instrument only Bedrock, call `configureTracing({ providers: ["bedrock"] })` in a bootstrap module and dynamically import the application afterward. See [Select Providers](/features/observability/traces/auto-instrumentation/overview#select-providers).
+
 ## Capture Prompts and Responses
 
-Bedrock request and response content is disabled by default because it can contain sensitive data. Set `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=span_only` before configuring tracing to add supported message content to PromptLayer spans.
+PromptLayer captures supported Bedrock request and response content by default. To export metadata-only telemetry, opt out before tracing is configured:
+
+<CodeGroup>
+```bash Python
+export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT="NO_CONTENT"
+```
+
+```bash JavaScript
+export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT="false"
+```
+</CodeGroup>
+
+JavaScript can instead pass `captureContent: false` to `configureTracing()`.
 
 Content coverage differs by Bedrock Runtime operation:
 
-| Operation | Content added to the PromptLayer span |
-| --- | --- |
-| `converse` | Request messages, system instructions, and the response message |
-| `converse_stream` | Request messages and system instructions; streamed response content is not added |
-| `invoke_model` and `invoke_model_with_response_stream` | Request and response bodies are not added |
+| Operation | Python content | JavaScript content |
+| --- | --- | --- |
+| Converse | Request messages, system instructions, and the response message | Request messages, system instructions, and the response message |
+| Converse streaming | Request messages and system instructions; streamed response content is not added | Not instrumented |
+| InvokeModel and InvokeModel streaming | Request and response bodies are not added | Not instrumented |
 
 All supported operations still include non-content telemetry supplied by the instrumentor, such as the model, timing, token usage when available, and errors.
 
 <Warning>
-Content capture can send user messages, model responses, system instructions, tool arguments and results, and other application data to PromptLayer. Review your privacy, retention, and compliance requirements before enabling it.
+Content capture can send user messages, model responses, system instructions, tool arguments and results, and other application data to PromptLayer. Because it is enabled by default, review your privacy, retention, and compliance requirements and opt out before the first Bedrock request when necessary.
 </Warning>
 
 ## Verify the Integration
 
-Run one supported Bedrock Runtime request, consume any response stream, flush tracing, and open [Traces](/features/observability/traces) in PromptLayer. The Bedrock span should have an associated request log and identify the Converse or InvokeModel API.
+Run one supported Bedrock Runtime request, consume any Python response stream, flush or shut down tracing, and open [Traces](/features/observability/traces) in PromptLayer. The Bedrock span should have an associated request log and identify the Converse or InvokeModel API.
 
 If no span appears:
 
 - Confirm instrumentation is configured before the first Bedrock Runtime request.
-- Confirm the Boto3 client uses `bedrock-runtime` and a method listed in [Supported APIs](#supported-apis).
+- Confirm the client and operation are listed for your language in [Supported APIs](#supported-apis).
+- In JavaScript, confirm the preload or bootstrap runs before `@aws-sdk/client-bedrock-runtime` loads.
 - Confirm `PROMPTLAYER_API_KEY` belongs to the workspace you are checking.
-- For streaming calls, fully consume or close the stream before flushing.
+- For Python streaming calls, fully consume or close the stream before flushing.
 - Flush tracing before a short-lived process exits.
-- If only message content is missing, check the content-capture value and the operation-specific coverage above, then restart the process.
+- If only message content is missing, confirm content capture was not disabled, check the operation-specific coverage above, and restart the process after changing the setting.

--- a/features/observability/traces/auto-instrumentation/google.mdx
+++ b/features/observability/traces/auto-instrumentation/google.mdx
@@ -8,15 +8,19 @@ PromptLayer can auto-instrument the Google GenAI SDK in both Gemini Developer AP
 
 ## Supported APIs
 
-| Google GenAI API | Python | JavaScript |
+| API surface | Python | JavaScript |
 | --- | --- | --- |
-| Generate Content | Sync and async | Supported |
-| Streaming Generate Content | Sync and async | Supported |
-| Embeddings | Sync and async | Not supported |
-| Interactions | Sync and async in supported Google GenAI SDK releases | Not supported |
+| Generate Content | Supported (sync and async) | Supported |
+| Generate Content streaming | Supported (sync and async) | Supported |
+| Chat | Not documented | Supported (`sendMessage`) |
+| Chat streaming | Not documented | Supported (`sendMessageStream`) |
+| Embeddings | Supported (sync and async) | Not supported |
+| Interactions | Supported (sync and async in supported SDK releases) | Not supported |
 | Vertex AI mode | Supported | Supported |
 
-In JavaScript, chat `sendMessage` and `sendMessageStream` calls are also traced. Other Google GenAI SDK calls continue to work normally, but unsupported surfaces do not automatically create PromptLayer traces or request logs.
+`Not documented` means the surface is outside the verified coverage for that language.
+
+Other Google GenAI SDK calls continue to work normally, but unsupported surfaces do not automatically create PromptLayer traces or request logs.
 
 ## Prerequisites
 
@@ -31,7 +35,7 @@ export PROMPTLAYER_API_KEY="pl_..."
 export GOOGLE_API_KEY="..."
 ```
 
-PromptLayer strongly recommends setting the language-specific [content-capture value](/features/observability/traces/auto-instrumentation/overview#capture-prompts-and-responses) so request inspection, search, analytics, and debugging can use prompts, responses, and tool content.
+PromptLayer captures supported message content by default. Review the [content-capture behavior and opt-out values](/features/observability/traces/auto-instrumentation/overview#capture-prompts-and-responses) before sending provider requests.
 
 ## Python
 

--- a/features/observability/traces/auto-instrumentation/openai.mdx
+++ b/features/observability/traces/auto-instrumentation/openai.mdx
@@ -12,12 +12,15 @@ This guide covers the OpenAI model SDK. If you use the OpenAI Agents SDK, follow
 
 ## Supported APIs
 
-| OpenAI API | Python | JavaScript |
+| API surface | Python | JavaScript |
 | --- | --- | --- |
-| Chat Completions (`chat.completions.create`) | Sync, async, and streaming | Supported, including streaming |
-| Structured-output parsing | Sync and async | Not supported |
-| Responses (`responses.create`) | Sync, async, and streaming | Supported, including streaming |
-| Embeddings (`embeddings.create`) | Sync and async | Supported |
+| Chat Completions (`chat.completions.create`) | Supported (sync and async) | Supported |
+| Chat Completions streaming | Supported (sync and async) | Supported |
+| Structured-output parsing | Supported (sync and async) | Not supported |
+| Responses (`responses.create`) | Supported (sync and async) | Supported |
+| Responses streaming | Supported (sync and async) | Supported |
+| Embeddings (`embeddings.create`) | Supported (sync and async) | Supported |
+| Azure OpenAI | Supported | Supported |
 
 Only the API surfaces in this table are auto-instrumented. Other OpenAI SDK calls continue to work normally, but this integration does not automatically create PromptLayer traces or request logs for them.
 
@@ -27,23 +30,21 @@ Only the API surfaces in this table are auto-instrumented. Other OpenAI SDK call
 - An OpenAI API key
 - Python 3.10 or later for the Python integration, or Node.js 20 or later for the JavaScript integration
 
-Export the variables for your language before the application starts. The API keys are required for the setup in this guide. Content capture is strongly recommended so PromptLayer can fully support request inspection, search, analytics, and debugging with your prompts, responses, and tool arguments.
+Export the variables for your language before the application starts. The API keys are required for the setup in this guide. PromptLayer captures supported prompt, response, and tool content by default.
 
 <CodeGroup>
 ```bash Python
 export PROMPTLAYER_API_KEY="pl_..."
 export OPENAI_API_KEY="sk_..."
-export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT="span_only"
 ```
 
 ```bash JavaScript
 export PROMPTLAYER_API_KEY="pl_..."
 export OPENAI_API_KEY="sk_..."
-export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT="true"
 ```
 </CodeGroup>
 
-Omit `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` only if your data policies require metadata-only telemetry without message contents. This limits content-aware PromptLayer features.
+If your data policies require metadata-only telemetry, use the language-specific opt-out in [Capture Prompts and Responses](#capture-prompts-and-responses) before starting the application. Disabling capture limits content-aware PromptLayer features.
 
 ## Python
 
@@ -176,12 +177,24 @@ The preload instruments every supported provider. To instrument only OpenAI, cal
 
 ## Capture Prompts and Responses
 
-Prompt and response content is disabled by default because it can contain sensitive data. PromptLayer strongly recommends enabling it when your data policies allow it so search, analytics, request inspection, and debugging can use the complete LLM interaction. Model names, timing, token usage when available, and other non-content telemetry are still recorded when capture is disabled.
+PromptLayer captures supported prompt and response content by default so search, analytics, request inspection, and debugging can use the complete LLM interaction. Model names, timing, token usage when available, and other non-content telemetry are still recorded when capture is disabled.
 
-The complete export blocks in [Prerequisites](#prerequisites) enable content capture. Use the language-specific value shown there, set it before `instrument_openai()` or the `promptlayer/register` preload runs, and restart an already-running process after changing it.
+To disable content capture, set the language-specific value before `instrument_openai()` or the `promptlayer/register` preload runs:
+
+<CodeGroup>
+```bash Python
+export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT="NO_CONTENT"
+```
+
+```bash JavaScript
+export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT="false"
+```
+</CodeGroup>
+
+JavaScript can instead pass `captureContent: false` to `configureTracing()`. Restart an already-running process after changing the setting.
 
 <Warning>
-Content capture can send user prompts, model responses, and tool arguments to PromptLayer. Review your privacy, retention, and compliance requirements before enabling it.
+Content capture can send user prompts, model responses, and tool arguments to PromptLayer. Because it is enabled by default, review your privacy, retention, and compliance requirements and opt out before the first OpenAI request when necessary.
 </Warning>
 
 ## Configuration Reference
@@ -192,7 +205,7 @@ Content capture can send user prompts, model responses, and tool arguments to Pr
 | `OPENAI_API_KEY` | Yes | Authenticates OpenAI SDK requests. It is read by OpenAI and is not sent to PromptLayer. |
 | `PROMPTLAYER_BASE_URL` | No | Overrides the PromptLayer API root. The tracing endpoint defaults to `<base-url>/v1/traces`. |
 | `PROMPTLAYER_OTLP_TRACES_ENDPOINT` | No | Overrides the complete OTLP/HTTP trace endpoint and takes precedence over `PROMPTLAYER_BASE_URL`. |
-| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | For content | Includes prompts, responses, and tool arguments. Use `span_only` for Python and `true` for JavaScript. |
+| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | No | Controls prompt, response, and tool content capture. Capture is enabled by default. Use `NO_CONTENT` for Python or `false` for JavaScript to disable it. |
 
 Python also accepts `api_key`, `base_url`, `endpoint`, and `tracer_provider` keyword arguments:
 
@@ -218,4 +231,4 @@ If no span appears:
 - Confirm the call uses an API surface listed in [Supported APIs](#supported-apis).
 - Confirm `PROMPTLAYER_API_KEY` belongs to the workspace you are checking.
 - Flush or shut down tracing before a short-lived process exits.
-- If only prompt or response content is missing, check the language-specific content-capture value and restart the process.
+- If only prompt or response content is missing, confirm content capture was not disabled and restart the process after changing the setting.

--- a/features/observability/traces/auto-instrumentation/overview.mdx
+++ b/features/observability/traces/auto-instrumentation/overview.mdx
@@ -37,7 +37,7 @@ For the resulting hierarchy and dashboard view, see [Traces](/features/observabi
     icon="aws"
     href="/features/observability/traces/auto-instrumentation/bedrock"
   >
-    Python
+    Python and JavaScript
   </Card>
 </CardGroup>
 
@@ -69,7 +69,7 @@ The Python instrumentation extra requires Python 3.10 or later. The core PromptL
 For JavaScript, install PromptLayer and the provider SDKs your application uses:
 
 ```bash
-npm install promptlayer openai @anthropic-ai/sdk @google/genai
+npm install promptlayer openai @anthropic-ai/sdk @google/genai @aws-sdk/client-bedrock-runtime
 ```
 
 Provider SDK modules must load after tracing is configured. In an ESM application, preload PromptLayer before the application module:
@@ -122,36 +122,32 @@ try {
 ```
 </CodeGroup>
 
-Supported selectors are `openai`, `anthropic`, and `google`. Python also supports `bedrock`, with `amazon.bedrock` and `aws.bedrock` as aliases for the Botocore instrumentor. Python accepts `openai.azure` as an alias for the OpenAI instrumentor. Anthropic Vertex uses `anthropic`; Google clients created with `vertexai=True` use `google`.
+Supported selectors are `openai`, `anthropic`, `google`, and `bedrock`. Python accepts `amazon.bedrock` and `aws.bedrock` as aliases for the Botocore instrumentor, and `openai.azure` as an alias for the OpenAI instrumentor. Anthropic Vertex uses `anthropic`; Google clients created with `vertexai=True` use `google`.
 
 Python applications that do not create a PromptLayer client can call `configure_tracing(providers=(...))`. The function returns the configured tracer provider so short-lived processes can call `force_flush()`.
 
 ## Capture Prompts and Responses
 
-Provider prompt and response content is disabled by default because it can contain sensitive data. PromptLayer strongly recommends enabling content capture when your data policies allow it. Content capture is crucial for getting the full value from PromptLayer search and analytics because it provides the prompt, response, and tool data used by request inspection, content search, analysis, and debugging.
+PromptLayer captures supported provider prompt and response content by default. This provides the prompt, response, and tool data used by request inspection, content search, analytics, and debugging.
 
-Without content capture, traces still include model names, timing, token usage when available, and other non-content telemetry. PromptLayer cannot search or analyze prompt, response, and tool content that was not exported.
-
-Set the language-specific value before tracing is configured:
+To export metadata-only telemetry, opt out before tracing is configured:
 
 <CodeGroup>
 ```bash Python
-export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT="span_only"
+export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT="NO_CONTENT"
 ```
 
 ```bash JavaScript
-export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT="true"
+export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT="false"
 ```
 </CodeGroup>
 
-JavaScript can instead pass `captureContent: true` to `configureTracing()`.
+JavaScript can instead pass `captureContent: false` to `configureTracing()`. Python defaults the official OpenTelemetry capture mode to `SPAN_ONLY` when PromptLayer enables provider instrumentation and preserves an explicitly configured `NO_CONTENT`, `SPAN_ONLY`, `EVENT_ONLY`, or `SPAN_AND_EVENT` value.
 
-<Tip>
-For the complete PromptLayer observability experience, enable content capture before your application makes its first provider request.
-</Tip>
+Without content capture, traces still include model names, timing, token usage when available, and other non-content telemetry. PromptLayer cannot search or analyze prompt, response, and tool content that was not exported.
 
 <Warning>
-Content capture can send user prompts, model responses, tool arguments, and other application data to PromptLayer. Review your privacy, retention, and compliance requirements before enabling it.
+Content capture can send user prompts, model responses, tool arguments, and other application data to PromptLayer. Because it is enabled by default, review your privacy, retention, and compliance requirements and opt out before the first provider request when necessary.
 </Warning>
 
 If a framework or agent SDK creates the provider client for you, use [Telemetry Integrations](/features/observability/traces/integrations). If no provider guide applies or you already own the telemetry pipeline, use [OpenTelemetry](/features/observability/traces/opentelemetry). See the [Tracing overview](/features/observability/traces) for the complete routing guide.

--- a/features/observability/traces/manual-tracing.mdx
+++ b/features/observability/traces/manual-tracing.mdx
@@ -40,7 +40,7 @@ const result = await pl.run({
 For the full `run()` interface, see the [Python SDK](/sdks/python#using-the-run-method-recommended) or [JavaScript SDK](/sdks/javascript#using-the-run-method-recommended).
 
 <Note>
-This setting also enables installed provider auto-instrumentation. To trace direct OpenAI, Anthropic, or Google GenAI SDK calls, or Boto3 Bedrock Runtime calls in Python, follow [SDK Auto-Instrumentation](/features/observability/traces/auto-instrumentation/overview) for the required packages, supported APIs, and JavaScript initialization order.
+This setting also enables installed provider auto-instrumentation. To trace direct OpenAI, Anthropic, or Google GenAI SDK calls, or Bedrock Runtime calls through Boto3 or AWS SDK v3, follow [SDK Auto-Instrumentation](/features/observability/traces/auto-instrumentation/overview) for the required packages, supported APIs, and JavaScript initialization order.
 </Note>
 
 ## Add Custom Spans

--- a/sdks/javascript.mdx
+++ b/sdks/javascript.mdx
@@ -18,7 +18,7 @@ npm install promptlayer
 
 ## Provider SDK Auto-Instrumentation
 
-PromptLayer can automatically trace supported direct OpenAI, Anthropic, and Google GenAI SDK calls. See [SDK Auto-Instrumentation](/features/observability/traces/auto-instrumentation/overview) for provider guides, the ESM preload command, content capture, and flushing.
+PromptLayer can automatically trace supported direct OpenAI, Anthropic, and Google GenAI SDK calls, plus AWS Bedrock Runtime `Converse` calls through AWS SDK v3. See [SDK Auto-Instrumentation](/features/observability/traces/auto-instrumentation/overview) for provider guides, the ESM preload command, content capture, and flushing.
 
 ## SDK evals
 


### PR DESCRIPTION
## Summary

- Document JavaScript AWS SDK v3 Bedrock Runtime `ConverseCommand` tracing, setup, and content coverage.
- Update Python and JavaScript provider guides for default-on message capture and their language-specific opt-outs.
- Standardize supported API tables across OpenAI, Anthropic, Google, and AWS Bedrock.
- Clarify language-specific Bedrock coverage and process-wide AWS SDK instrumentation behavior.

This aligns the docs with MagnivOrg/prompt-layer-js#195 and MagnivOrg/prompt-layer-library#342.

## Validation

- `mint validate`
- `mint broken-links`
- `git diff --check`